### PR TITLE
Add web display option to connect python script to frontend

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -36,6 +36,16 @@ export default function DashboardPage() {
     process.env.NEXT_PUBLIC_EYE_STREAM_URL ?? "http://127.0.0.1:5001/eye.mjpg";
   const sceneStreamUrl =
     process.env.NEXT_PUBLIC_SCENE_STREAM_URL ?? "http://127.0.0.1:5001/scene.mjpg";
+  const loadCalibrationUrl =
+    process.env.NEXT_PUBLIC_LOAD_CALIBRATION_URL ?? "http://127.0.0.1:5001/load";
+
+  const handleLoadCalibration = async () => {
+    try {
+      await fetch(loadCalibrationUrl);
+    } catch (err) {
+      console.error("Failed to request calibration load:", err);
+    }
+  };
 
   return (
     <div className="flex min-h-screen flex-col bg-[#121212] font-sans text-white">
@@ -62,17 +72,26 @@ export default function DashboardPage() {
 
       <div className="flex flex-1 flex-col gap-4 p-4 lg:flex-row">
         <section className="flex min-h-[360px] flex-1 flex-col rounded-2xl border border-white p-6 lg:min-h-0">
-          <h2 className="mb-2 text-lg font-semibold">Eye Tracker</h2>
+          <div className="mb-2 flex items-center justify-between gap-4">
+            <h2 className="text-lg font-semibold">Eye Tracker</h2>
+            <button
+              type="button"
+              onClick={handleLoadCalibration}
+              className="rounded-full border border-white bg-black px-4 py-1.5 text-xs font-medium text-white hover:bg-zinc-900"
+            >
+              Load Calibration
+            </button>
+          </div>
           <p className="mb-6 max-w-xl text-sm leading-relaxed text-zinc-300">
-            Displays a red circle in relation to where the user is looking on
+            Displays a green dot in relation to where the user is looking on
             the screen here.
           </p>
-          <div className="relative min-h-[240px] flex-1 overflow-hidden rounded-xl bg-black">
+          <div className="relative mx-auto aspect-[4/3] w-full max-w-[640px] overflow-hidden rounded-xl bg-black">
             {/* eslint-disable-next-line @next/next/no-img-element -- MJPEG stream from Flask; next/image does not support this */}
             <img
               src={sceneStreamUrl}
               alt="Scene camera with gaze overlay"
-              className="h-full min-h-[240px] w-full object-contain"
+              className="h-full w-full object-contain"
             />
           </div>
         </section>
@@ -124,7 +143,7 @@ export default function DashboardPage() {
         <h3 className="mb-3 text-sm font-medium text-white">Session Log:</h3>
         <pre className="font-mono text-sm leading-relaxed text-[#4CAF50]">
           {`> Camera stream initialized
-> Handshake with Raspberry Pi successful
+> Handshake with Jetson successful
 > Calibration loaded (Profile: User_01)`}
         </pre>
       </footer>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -31,9 +31,11 @@ export default function DashboardPage() {
     );
   }
 
-  /** `python scripts/linux_cam_stream.py` → MJPEG at this URL */
-  const cameraStreamUrl =
-    process.env.NEXT_PUBLIC_CAMERA_STREAM_URL ?? "http://127.0.0.1:5000/";
+  /** `python -m scripts.eyetracker --web` → MJPEG at these URLs */
+  const eyeStreamUrl =
+    process.env.NEXT_PUBLIC_EYE_STREAM_URL ?? "http://127.0.0.1:5001/eye.mjpg";
+  const sceneStreamUrl =
+    process.env.NEXT_PUBLIC_SCENE_STREAM_URL ?? "http://127.0.0.1:5001/scene.mjpg";
 
   return (
     <div className="flex min-h-screen flex-col bg-[#121212] font-sans text-white">
@@ -68,13 +70,10 @@ export default function DashboardPage() {
           <div className="relative min-h-[240px] flex-1 overflow-hidden rounded-xl bg-black">
             {/* eslint-disable-next-line @next/next/no-img-element -- MJPEG stream from Flask; next/image does not support this */}
             <img
-              src={cameraStreamUrl}
-              alt="Live camera"
+              src={sceneStreamUrl}
+              alt="Scene camera with gaze overlay"
               className="h-full min-h-[240px] w-full object-contain"
             />
-            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-              <div className="h-8 w-8 rounded-full border-2 border-red-500 bg-transparent" />
-            </div>
           </div>
         </section>
 
@@ -84,10 +83,12 @@ export default function DashboardPage() {
               Internal Eye Feed
             </div>
             <div className="relative flex flex-1 items-center justify-center bg-black">
-              <div className="absolute inset-0 bg-gradient-to-br from-zinc-800 to-black" />
-              <span className="relative z-10 text-xs text-zinc-500">
-                Eye camera preview
-              </span>
+              {/* eslint-disable-next-line @next/next/no-img-element -- MJPEG stream from Flask; next/image does not support this */}
+              <img
+                src={eyeStreamUrl}
+                alt="Eye camera with pupil detection overlay"
+                className="h-full w-full object-contain"
+              />
             </div>
           </div>
 

--- a/scripts/eyetracker/__main__.py
+++ b/scripts/eyetracker/__main__.py
@@ -4,6 +4,8 @@ This is the only place that decides which concrete implementation of each
 ABC to use. Swap a class here (e.g. PolynomialGazeMapper -> TpsGazeMapper)
 and nothing else needs to change.
 """
+import argparse
+
 import cv2
 
 from scripts.eyetracker.app import App
@@ -30,6 +32,7 @@ from scripts.eyetracker.config import (
 from scripts.eyetracker.display.cv_display import CvDisplay
 from scripts.eyetracker.display.selection_gui import SelectionGui
 from scripts.eyetracker.display.tk_overlay import TkCalibrationOverlay
+from scripts.eyetracker.display.web_display import WebDisplay
 from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
 from scripts.eyetracker.gaze.smoothing import MovingAverageSmoother
 from scripts.eyetracker.pupil.gating import ConfidenceGate, JumpGate
@@ -49,7 +52,7 @@ def _scene_cam_settings() -> CameraSettings:
                           request_height=SCENE_REQUEST_HEIGHT)
 
 
-def _build_app(eye_index: int) -> App:
+def _build_app(eye_index: int, web: bool = False) -> App:
     eye_cam = OpenCVCamera(eye_index, _eye_cam_settings())
     scene_index = 1 if eye_index == 0 else 0
     scene_cam = OpenCVCamera(scene_index, _scene_cam_settings())
@@ -80,7 +83,7 @@ def _build_app(eye_index: int) -> App:
         target_mapper=target_mapper,
         routine=routine,
         overlay=TkCalibrationOverlay(target_mapper=target_mapper),
-        display=CvDisplay(with_scene=True),
+        display=WebDisplay() if web else CvDisplay(with_scene=True),
     )
 
 
@@ -124,13 +127,21 @@ def _run_video(path: str) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(prog="scripts.eyetracker")
+    parser.add_argument(
+        "--web", action="store_true",
+        help="Stream annotated frames over HTTP (MJPEG) instead of "
+             "opening cv2.imshow windows. See display/web_display.py.",
+    )
+    args = parser.parse_args()
+
     cameras = detect_cameras()
     result = SelectionGui().pick(cameras)
     if result is None:
         return
     kind, val = result
     if kind == "camera":
-        _build_app(int(val)).run()
+        _build_app(int(val), web=args.web).run()
     elif kind == "video":
         _run_video(str(val))
 

--- a/scripts/eyetracker/display/web_display.py
+++ b/scripts/eyetracker/display/web_display.py
@@ -3,7 +3,13 @@
 Mirrors the framing/annotation behavior of CvDisplay (scene downscale +
 gaze dot drawing) but pushes JPEG-encoded bytes to two HTTP endpoints
 instead of cv2.imshow windows. Used by the Next.js dashboard.
+
+Also exposes a small set of command endpoints (e.g. /load) that inject
+a key char into a queue; poll_key drains the queue so the App's existing
+key handler (`l` -> load calibration) does the work without any new
+coupling between the Display and the App.
 """
+import queue
 import threading
 import time
 from typing import Optional, Tuple
@@ -49,6 +55,7 @@ class WebDisplay(Display):
 
         self._eye = _FrameSlot()
         self._scene = _FrameSlot()
+        self._key_queue: "queue.Queue[str]" = queue.Queue()
         self._app = Flask(__name__)
         self._register_routes()
         self._server_thread: Optional[threading.Thread] = None
@@ -57,21 +64,27 @@ class WebDisplay(Display):
     def _register_routes(self) -> None:
         app = self._app
 
-        @app.after_request
+        @app.after_request  # pyright: ignore[reportUnusedFunction]
         def _cors(resp):
             resp.headers["Access-Control-Allow-Origin"] = "*"
             resp.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
             return resp
 
-        @app.route("/eye.mjpg")
+        @app.route("/eye.mjpg")  # pyright: ignore[reportUnusedFunction]
         def eye_feed():
             return Response(_mjpeg_generator(self._eye),
                             mimetype="multipart/x-mixed-replace; boundary=frame")
 
-        @app.route("/scene.mjpg")
+        @app.route("/scene.mjpg")  # pyright: ignore[reportUnusedFunction]
         def scene_feed():
             return Response(_mjpeg_generator(self._scene),
                             mimetype="multipart/x-mixed-replace; boundary=frame")
+
+        # Plain GET so browsers don't preflight; idempotent enough for MVP.
+        @app.route("/load", methods=["GET", "POST"])  # pyright: ignore[reportUnusedFunction]
+        def load_calibration():
+            self._key_queue.put("l")
+            return ("", 204)
 
     # ---- Display interface -------------------------------------------------
 
@@ -110,11 +123,16 @@ class WebDisplay(Display):
             self._scene.put(encoded)
 
     def poll_key(self) -> Tuple[Optional[str], int]:
-        # Web display has no key input; calibration keys come from the Tk overlay.
-        # Sleep a touch so the App loop doesn't pin a core when neither cam has
-        # produced a frame yet.
+        # Web display has no real keyboard; HTTP endpoints push command keys
+        # (e.g. 'l' from /load) into the queue and we surface them here so
+        # App._handle_key dispatches them like any other keypress.
         time.sleep(0.001)
-        return None, 255
+        try:
+            ch = self._key_queue.get_nowait()
+        except queue.Empty:
+            return None, 255
+        raw = ord(ch) if len(ch) == 1 else 255
+        return ch, raw
 
     def wait_for_pause(self) -> None:
         time.sleep(0.05)

--- a/scripts/eyetracker/display/web_display.py
+++ b/scripts/eyetracker/display/web_display.py
@@ -1,0 +1,143 @@
+"""Flask-based Display that streams the eye and scene frames as MJPEG.
+
+Mirrors the framing/annotation behavior of CvDisplay (scene downscale +
+gaze dot drawing) but pushes JPEG-encoded bytes to two HTTP endpoints
+instead of cv2.imshow windows. Used by the Next.js dashboard.
+"""
+import threading
+import time
+from typing import Optional, Tuple
+
+import cv2
+import numpy as np
+from flask import Flask, Response
+
+from scripts.eyetracker.config import DISPLAY_HEIGHT, DISPLAY_WIDTH
+from scripts.eyetracker.display.base import Display, XY
+
+
+_JPEG_QUALITY = 70
+
+
+class _FrameSlot:
+    """Latest-frame slot. Producers write bytes; consumers wait on `event`
+    for a new frame, read `data`, and clear the event before re-waiting."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._data: Optional[bytes] = None
+        self.event = threading.Event()
+
+    def put(self, data: bytes) -> None:
+        with self._lock:
+            self._data = data
+        self.event.set()
+
+    def get(self) -> Optional[bytes]:
+        with self._lock:
+            return self._data
+
+
+class WebDisplay(Display):
+    def __init__(self,
+                 host: str = "127.0.0.1",
+                 port: int = 5001,
+                 display_size: Tuple[int, int] = (DISPLAY_WIDTH, DISPLAY_HEIGHT)):
+        self.host = host
+        self.port = port
+        self.display_w, self.display_h = display_size
+
+        self._eye = _FrameSlot()
+        self._scene = _FrameSlot()
+        self._app = Flask(__name__)
+        self._register_routes()
+        self._server_thread: Optional[threading.Thread] = None
+        self._opened = False
+
+    def _register_routes(self) -> None:
+        app = self._app
+
+        @app.after_request
+        def _cors(resp):
+            resp.headers["Access-Control-Allow-Origin"] = "*"
+            resp.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+            return resp
+
+        @app.route("/eye.mjpg")
+        def eye_feed():
+            return Response(_mjpeg_generator(self._eye),
+                            mimetype="multipart/x-mixed-replace; boundary=frame")
+
+        @app.route("/scene.mjpg")
+        def scene_feed():
+            return Response(_mjpeg_generator(self._scene),
+                            mimetype="multipart/x-mixed-replace; boundary=frame")
+
+    # ---- Display interface -------------------------------------------------
+
+    def open(self) -> None:
+        if self._opened:
+            return
+        self._server_thread = threading.Thread(
+            target=lambda: self._app.run(host=self.host, port=self.port,
+                                         threaded=True, debug=False,
+                                         use_reloader=False),
+            daemon=True,
+        )
+        self._server_thread.start()
+        self._opened = True
+        print(f"WebDisplay: streaming at http://{self.host}:{self.port}/"
+              f"{{eye,scene}}.mjpg")
+
+    def close(self) -> None:
+        # Daemon thread dies with the process; nothing to do.
+        self._opened = False
+
+    def show_eye(self, frame: np.ndarray) -> None:
+        encoded = _encode_jpeg(frame)
+        if encoded is not None:
+            self._eye.put(encoded)
+
+    def show_scene(self, frame: np.ndarray, gaze_xy: Optional[XY]) -> None:
+        scene_h, scene_w = frame.shape[:2]
+        resized = cv2.resize(frame, (self.display_w, self.display_h))
+        if gaze_xy is not None and scene_w > 0 and scene_h > 0:
+            disp_x = int(gaze_xy[0] * self.display_w / scene_w)
+            disp_y = int(gaze_xy[1] * self.display_h / scene_h)
+            cv2.circle(resized, (disp_x, disp_y), 8, (0, 255, 0), -1)
+        encoded = _encode_jpeg(resized)
+        if encoded is not None:
+            self._scene.put(encoded)
+
+    def poll_key(self) -> Tuple[Optional[str], int]:
+        # Web display has no key input; calibration keys come from the Tk overlay.
+        # Sleep a touch so the App loop doesn't pin a core when neither cam has
+        # produced a frame yet.
+        time.sleep(0.001)
+        return None, 255
+
+    def wait_for_pause(self) -> None:
+        time.sleep(0.05)
+
+
+def _encode_jpeg(frame: np.ndarray) -> Optional[bytes]:
+    ok, buf = cv2.imencode(".jpg", frame,
+                           [int(cv2.IMWRITE_JPEG_QUALITY), _JPEG_QUALITY])
+    if not ok:
+        return None
+    return buf.tobytes()
+
+
+def _mjpeg_generator(slot: _FrameSlot):
+    """Yield multipart frames whenever the slot gets a new frame.
+    Waits on the slot's event so we don't busy-loop or send duplicates."""
+    while True:
+        slot.event.wait()
+        slot.event.clear()
+        data = slot.get()
+        if data is None:
+            continue
+        yield (b"--frame\r\n"
+               b"Content-Type: image/jpeg\r\n"
+               b"Content-Length: " + str(len(data)).encode() + b"\r\n\r\n"
+               + data + b"\r\n")


### PR DESCRIPTION
# Summary                                                                                                                                        
  
  Wires the live Python eye tracker (scripts/eyetracker/) to the Next.js dashboard at /dashboard, so the annotated eye-cam and scene-cam feeds render directly in the browser. Streaming is opt-in via a `--web` flag — running `python -m scripts.eyetracker` with no flag still opens the cv2 windows exactly as before, so local testing is unaffected.                                                                                     
                                                                                                                                               
 # How it works

  Adds a new WebDisplay implementation of the existing Display ABC. It runs an embedded Flask server on `127.0.0.1:5001` with two MJPEG endpoints  
  (`/eye.mjpg`, `/scene.mjpg`) that serve the already-annotated frames produced by the App pipeline (pupil ellipses, gaze dot, etc.). The `__main__.py`
   composition root selects WebDisplay vs CvDisplay based on the new --web flag — no changes to the App loop, cameras, pupil detection, gaze     
  mapping, or calibration code.                                                                                                                

  A small command channel layers on top: HTTP endpoints push key chars into a thread-safe queue, and WebDisplay.poll_key() drains it, so the     
  App's existing _handle_key dispatches them like real keypresses with no new coupling. For this iteration only 'l' is wired up, exposed via a
  "Load Calibration" button on the dashboard.                                                                                                    
                                                                                                                                               
 # Files changed

  - scripts/eyetracker/display/web_display.py (new) — WebDisplay(Display) with daemon-thread Flask server, per-stream Event-driven MJPEG         
  generators, scene downscaling + gaze-dot drawing mirrored from CvDisplay, JPEG quality 70, CORS via after_request, key-injection queue, and
  /load endpoint.                                                                                                                                
  - scripts/eyetracker/__main__.py — argparse with --web flag; _build_app(eye_index, web) selects display implementation.                      
  - frontend/app/dashboard/page.tsx — main pane wired to scene MJPEG (capped at max-w-[640px] with aspect-[4/3] so it doesn't dominate the       
  layout); sidebar "Internal Eye Feed" wired to eye MJPEG; "Load Calibration" button next to the heading; removed the static red-circle overlay  
  (the real green gaze dot is drawn server-side).                                                                                                
  - frontend/.env.local — added NEXT_PUBLIC_EYE_STREAM_URL, NEXT_PUBLIC_SCENE_STREAM_URL, NEXT_PUBLIC_LOAD_CALIBRATION_URL.                      
                                                                                                                                                 
 # Out of scope (deferred for a follow-up)
                                                                                                                                                 
  - Starting/stopping the Python process from the frontend (still launched manually from a terminal).                                            
  - Live metrics on the dashboard (vid rate, Gaze X/Y, Accuracy, Latency) — placeholders for now; would need a separate SSE/WebSocket channel.
  - Other keyboard commands beyond load (c calibrate, r reset model, q quit) — easy follow-up using the same key-queue mechanism.                
                                                                                                                                                 
 # Test plan                                                                                                                                      
                                                                                                                                                 
  - Default flow regression: python -m scripts.eyetracker (no flag) → cv2 windows still open with pupil markers and gaze dot.                    
  - Web mode direct: python -m scripts.eyetracker --web → pick a camera → visit http://127.0.0.1:5001/eye.mjpg and /scene.mjpg in plain browser
  tabs; both show live annotated streams.                                                                                                        
  - Calibration via Tk overlay still works in web mode (focus the Tk overlay, press c).                                                        
  - Frontend integration: cd frontend && npm run dev → log in → /dashboard shows both feeds at sensible sizes; no CORS errors in devtools        
  console.                                                                                                                                       
  - Click "Load Calibration" on the dashboard → green gaze dot appears on the scene feed.                                                        
  - Ctrl+C the Python process → feeds freeze (acceptable for MVP).     