### PR TITLE
Replace MA smoother with 1€ filter for adaptive gaze smoothing

### DIFF
--- a/scripts/eyetracker/__main__.py
+++ b/scripts/eyetracker/__main__.py
@@ -15,7 +15,9 @@ from scripts.eyetracker.calibration.targets import GridPattern
 from scripts.eyetracker.cameras.discovery import detect_cameras
 from scripts.eyetracker.cameras.opencv_source import CameraSettings, OpenCVCamera
 from scripts.eyetracker.config import (
-    GAZE_BUFFER_SIZE,
+    GAZE_BETA,
+    GAZE_D_CUTOFF,
+    GAZE_MIN_CUTOFF,
     CALIB_INLIERS,
     CALIB_SAMPLES,
     CALIB_SCENE_STD_THRESH,
@@ -34,7 +36,7 @@ from scripts.eyetracker.display.selection_gui import SelectionGui
 from scripts.eyetracker.display.tk_overlay import TkCalibrationOverlay
 from scripts.eyetracker.display.web_display import WebDisplay
 from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
-from scripts.eyetracker.gaze.smoothing import MovingAverageSmoother
+from scripts.eyetracker.gaze.smoothing import OneEuroSmoother
 from scripts.eyetracker.pupil.gating import ConfidenceGate, JumpGate
 from scripts.eyetracker.pupil.pupil_labs import PupilLabsDetector
 from scripts.eyetracker.scene.aruco_homography import ArucoHomography
@@ -79,7 +81,9 @@ def _build_app(eye_index: int, web: bool = False) -> App:
         jump_gate=JumpGate(threshold_px=PUPIL_JUMP_THRESH,
                            buffer_size=PUPIL_BUFFER_SIZE),
         mapper=mapper,
-        smoother=MovingAverageSmoother(window=GAZE_BUFFER_SIZE),
+        smoother=OneEuroSmoother(min_cutoff=GAZE_MIN_CUTOFF,
+                                 beta=GAZE_BETA,
+                                 d_cutoff=GAZE_D_CUTOFF),
         target_mapper=target_mapper,
         routine=routine,
         overlay=TkCalibrationOverlay(target_mapper=target_mapper),

--- a/scripts/eyetracker/app.py
+++ b/scripts/eyetracker/app.py
@@ -20,7 +20,7 @@ from scripts.eyetracker.cameras.base import CameraSource
 from scripts.eyetracker.cameras.utils import crop_to_aspect_ratio
 from scripts.eyetracker.display.base import CalibrationOverlay, Display
 from scripts.eyetracker.gaze.base import GazeMapper
-from scripts.eyetracker.gaze.smoothing import MovingAverageSmoother
+from scripts.eyetracker.gaze.smoothing import OneEuroSmoother
 from scripts.eyetracker.pupil.base import PupilDetector
 from scripts.eyetracker.pupil.gating import ConfidenceGate, JumpGate
 from scripts.eyetracker.scene.aruco_homography import ArucoHomography
@@ -38,7 +38,7 @@ class App:
                  conf_gate: ConfidenceGate,
                  jump_gate: JumpGate,
                  mapper: GazeMapper,
-                 smoother: MovingAverageSmoother,
+                 smoother: OneEuroSmoother,
                  target_mapper: ArucoHomography,
                  routine: CalibrationRoutine,
                  overlay: CalibrationOverlay,

--- a/scripts/eyetracker/config.py
+++ b/scripts/eyetracker/config.py
@@ -47,8 +47,13 @@ PUPIL_BUFFER_SIZE = 7
 PUPIL_JUMP_THRESH = 400.0
 
 
-# ---- Gaze smoothing ----------------------------------------------------------
-GAZE_BUFFER_SIZE = 5
+# ---- Gaze smoothing (1€ filter) ----------------------------------------------
+# min_cutoff: low-speed cutoff (Hz). Lower = steadier fixations, more lag.
+# beta: speed coefficient. Higher = tracks saccades faster, less smoothing.
+# d_cutoff: cutoff on the speed estimate; rarely needs tuning.
+GAZE_MIN_CUTOFF = 1.0
+GAZE_BETA = 0.05
+GAZE_D_CUTOFF = 1.0
 
 
 # ---- Calibration -------------------------------------------------------------

--- a/scripts/eyetracker/gaze/smoothing.py
+++ b/scripts/eyetracker/gaze/smoothing.py
@@ -1,27 +1,69 @@
-"""Trailing moving-average smoothing for predicted gaze points.
-"""
-from collections import deque
-from typing import Tuple
+"""1€ filter (Casiez et al., 2012) for predicted gaze points.
 
-import numpy as np
+Adaptive low-pass: cutoff rises with signal speed, so fixations get heavy
+smoothing and saccades pass through with little lag. Tuning: lower
+`min_cutoff` for steadier fixations; raise `beta` to track fast motion
+more aggressively.
+"""
+import math
+import time
+from typing import Optional, Tuple
 
 
 XY = Tuple[float, float]
 
 
-class MovingAverageSmoother:
-    def __init__(self, window: int):
-        """
-        Params:
-            In __main__.py we use GAZE_BUFFER_SIZE for `window` here
-        """
-        self._buf: deque = deque(maxlen=window)
+def _alpha(dt: float, cutoff: float) -> float:
+    tau = 1.0 / (2.0 * math.pi * cutoff)
+    return 1.0 / (1.0 + tau / dt)
+
+
+class _Channel:
+    def __init__(self, min_cutoff: float, beta: float, d_cutoff: float):
+        self.min_cutoff = min_cutoff
+        self.beta = beta
+        self.d_cutoff = d_cutoff
+        self.x_prev: Optional[float] = None
+        self.dx_prev: float = 0.0
 
     def reset(self) -> None:
-        self._buf.clear()
+        self.x_prev = None
+        self.dx_prev = 0.0
+
+    def filter(self, x: float, dt: float) -> float:
+        if self.x_prev is None:
+            self.x_prev = x
+            return x
+        dx = (x - self.x_prev) / dt
+        a_d = _alpha(dt, self.d_cutoff)
+        dx_hat = a_d * dx + (1.0 - a_d) * self.dx_prev
+        cutoff = self.min_cutoff + self.beta * abs(dx_hat)
+        a = _alpha(dt, cutoff)
+        x_hat = a * x + (1.0 - a) * self.x_prev
+        self.x_prev = x_hat
+        self.dx_prev = dx_hat
+        return x_hat
+
+
+class OneEuroSmoother:
+    def __init__(self,
+                 min_cutoff: float = 1.0,
+                 beta: float = 0.05,
+                 d_cutoff: float = 1.0):
+        self._u = _Channel(min_cutoff, beta, d_cutoff)
+        self._v = _Channel(min_cutoff, beta, d_cutoff)
+        self._t_prev: Optional[float] = None
+
+    def reset(self) -> None:
+        self._u.reset()
+        self._v.reset()
+        self._t_prev = None
 
     def add(self, point: XY) -> XY:
-        self._buf.append(point)
-        avg_u = float(np.mean([p[0] for p in self._buf]))
-        avg_v = float(np.mean([p[1] for p in self._buf]))
-        return avg_u, avg_v
+        t = time.monotonic()
+        if self._t_prev is None:
+            dt = 1.0 / 30.0
+        else:
+            dt = max(t - self._t_prev, 1e-6)
+        self._t_prev = t
+        return self._u.filter(point[0], dt), self._v.filter(point[1], dt)


### PR DESCRIPTION
Fixed-window moving average forces a single noise/lag tradeoff. The 1€ filter (Casiez et al., 2012) raises the low-pass cutoff with signal speed, so fixations get heavy smoothing while saccades pass through with little lag. Drop-in: same add()/reset() interface; uses time.monotonic() internally so callers don't need to pass timestamps.

Replaces GAZE_BUFFER_SIZE with GAZE_MIN_CUTOFF / GAZE_BETA / GAZE_D_CUTOFF.