### PR TITLE
Update README docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@ A high-precision, low-latency eye tracker prototype. Eventual use cases include 
 
 A head-mounted rig pairs an IR eye camera with a forward-facing scene camera. A Python pipeline detects the pupil, calibrates a polynomial mapping from pupil pixels to scene-camera pixels, and either renders the gaze locally (OpenCV) or streams annotated frames over HTTP for a Next.js dashboard to overlay.
 
+## Install
+
+**Python backend** (3.11+ recommended):
+
+```
+brew install eigen opencv                       # macOS system deps for pupil-detectors
+git clone https://github.com/pupil-labs/pupil-detectors.git ../pupil-detectors
+pip install -r requirements.txt                 # installs the local pupil-detectors clone
+```
+
+`requirements.txt` references `../pupil-detectors` as a local path; adjust the clone location or edit the path if your layout differs. `pye3d` ships from PyPI.
+
+**Frontend** (Node 20+):
+
+```
+cd frontend
+npm install
+cp .env.local.example .env.local                # then fill in the two Supabase keys
+```
+
+`frontend/.env.local` needs:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+```
+
+**Hardware** — head-mounted rig with an IR eye camera and a forward-facing scene camera (USB UVC). Calibration draws four ArUco markers (`DICT_4X4_50`, IDs 0/1/2/3) directly onto the laptop screen — nothing to print or mount.
+
 ## Running
 
 Backend (eye tracker only):
@@ -114,7 +143,14 @@ See [`docs/polynomial_gaze_mapping.md`](docs/polynomial_gaze_mapping.md) for the
 - **Python** — [PEP 8](https://peps.python.org/pep-0008/). Enforced by `flake8` in CI (`.github/workflows/linter.yml`): blocking on `E9`/`F63`/`F7`/`F82` (syntax errors, undefined names), with line length 127 and McCabe complexity 10 as non-blocking warnings. Public-facing modules, classes, and functions carry docstrings.
 - **TypeScript / React** — Next.js ESLint preset (`eslint-config-next/core-web-vitals` + `eslint-config-next/typescript`), configured in `frontend/eslint.config.mjs`. `frontend/tsconfig.json` enables `strict: true`. Exported React components carry JSDoc.
 
-External references the project relies on are catalogued in [`docs/citations/references.bib`](docs/citations/references.bib); the system architecture lives in [`docs/architecture/workspace.dsl`](docs/architecture/workspace.dsl) (Structurizr DSL, renders at <https://structurizr.com/dsl>).
+## Design & architecture
+
+- **UI wireframes** — [Opticore on Figma](https://www.figma.com/design/WKvgVunFAci4GsTFlWHqsr/Opticore?node-id=0-1&p=f)
+- **C4 architecture model** — [`docs/architecture/workspace.dsl`](docs/architecture/workspace.dsl) (Structurizr DSL with C1/C2/C3 views). To render:
+  1. Open <https://structurizr.com/dsl>
+  2. Paste the contents of `workspace.dsl` into the left-hand editor
+  3. Use the diagram dropdown to switch between the System Context (C1), Container (C2), and Component (C3) views
+- **External references** — catalogued in [`docs/citations/references.bib`](docs/citations/references.bib)
 
 ## Roadmap
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,6 @@
+# Copy this file to `.env.local` and fill in the values.
+# Both keys are public — the anon key is safe to ship to the browser.
+# DO NOT put the Supabase service-role key in this file (or any NEXT_PUBLIC_* var).
+
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,59 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Eye Tracker — Frontend
 
-## Getting Started
+Next.js 16 / React 19 dashboard for the Eye Tracker project. Authenticates with Supabase, consumes MJPEG streams from the Python backend, and overlays live gaze (`GazeDot`) and session heatmaps (`HeatmapCanvas`).
 
-First, run the development server:
+See the [root README](../README.md) for the full system overview and the [Figma wireframes](https://www.figma.com/design/WKvgVunFAci4GsTFlWHqsr/Opticore?node-id=0-1&p=f) for the intended UI.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## Install
+
+Requires Node 20+.
+
+```
+npm install
+cp .env.local.example .env.local    # then fill in the two Supabase keys
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+`.env.local` must define:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Both are public (the anon key is safe to ship to the browser); never put the Supabase service-role key in this file. `lib/supabase.ts` throws at startup if either is missing.
 
-## Learn More
+## Run
 
-To learn more about Next.js, take a look at the following resources:
+```
+npm run dev          # dev server at http://localhost:3000
+npm run build        # production build
+npm run start        # serve the production build
+npm run lint         # Next.js ESLint preset
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Open <http://localhost:3000>, sign up or log in, then click **Load Calibration** to reuse the most recent saved fit from the backend.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Backend dependency
 
-## Deploy on Vercel
+The dashboard expects the Python backend running in web mode in a separate terminal (from the repo root):
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+```
+py -m scripts.eyetracker --web
+```
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+That mode replaces the local cv2 windows with Flask MJPEG endpoints the dashboard pulls from. Without it, the gaze / camera panels will show blank streams.
+
+## Layout
+
+```
+app/                # Next.js app-router pages
+    dashboard/      # calibration, games, heatmap, ml-analytics, profile
+    login/          # Supabase email/password login
+    signup/         # Supabase signup
+components/         # GazeDot, HeatmapCanvas
+lib/supabase.ts     # Supabase browser client
+```
+
+## Code style
+
+Next.js ESLint preset (`eslint-config-next/core-web-vitals` + `eslint-config-next/typescript`), configured in `eslint.config.mjs`. `tsconfig.json` enables `strict: true`. Exported React components carry JSDoc.

--- a/scripts/eyetracker/README.md
+++ b/scripts/eyetracker/README.md
@@ -1,0 +1,63 @@
+# Eye Tracker — Backend
+
+Python pipeline that detects the pupil, calibrates a polynomial mapping from pupil pixels to scene-camera pixels, and either renders the gaze locally (OpenCV) or streams annotated frames over HTTP for the Next.js dashboard to overlay.
+
+See the [root README](../../README.md) for the full system overview.
+
+## Install
+
+Python 3.11+ recommended.
+
+```
+brew install eigen opencv                       # macOS system deps for pupil-detectors
+git clone https://github.com/pupil-labs/pupil-detectors.git ../../../pupil-detectors
+pip install -r ../../requirements.txt           # installs the local pupil-detectors clone
+```
+
+`requirements.txt` references `../pupil-detectors` as a local path relative to the repo root; adjust the clone location or edit the path if your layout differs. `pye3d` ships from PyPI.
+
+**Hardware** — head-mounted rig with an IR eye camera and a forward-facing scene camera (USB UVC). Calibration draws four ArUco markers (`DICT_4X4_50`, IDs 0/1/2/3) directly onto the laptop screen — nothing to print or mount.
+
+## Run
+
+From the repo root:
+
+```
+py -m scripts.eyetracker            # local cv2 windows
+py -m scripts.eyetracker --web      # serves MJPEG endpoints for the dashboard
+```
+
+In web mode, run the Next.js frontend in a separate terminal (see [`frontend/README.md`](../../frontend/README.md)).
+
+## In-app controls
+
+| Key | Action |
+| --- | --- |
+| `c` | Quick calibration (4×3 grid, degree-2 polynomial) |
+| `d` | Detailed calibration (5×4 grid, degree-3 polynomial, with worst-point recapture) |
+| `l` | Load most recent saved calibration |
+| `r` | Reset the pye3d 3D pupil model (give it ~30 s to reconverge) |
+| `space` | Pause |
+| `q` | Quit |
+
+Calibration displays four ArUco markers (IDs 0/1/2/3, `DICT_4X4_50`) at the corners of the laptop screen — they let the routine project each target's screen pixel into the scene camera to manufacture training labels.
+
+## Layout
+
+```
+__main__.py             # Composition root: wires concrete classes into App
+app.py                  # Main loop, frame routing, key dispatch
+config.py               # All tunables (camera, calibration grid, smoother, ArUco)
+cameras/                # OpenCV camera sources + discovery
+pupil/                  # Pupil Labs detector + confidence/jump gates
+scene/                  # ArUco detection and screen→scene homography
+gaze/                   # Polynomial mapper, 1€ smoother
+calibration/            # State machine, sample collector, persistence
+display/                # Tk calibration overlay, cv2 windows, Flask MJPEG server
+```
+
+See [`docs/polynomial_gaze_mapping.md`](../../docs/polynomial_gaze_mapping.md) for the math behind the pupil→scene fit and why the homography only shows up during calibration.
+
+## Code style
+
+[PEP 8](https://peps.python.org/pep-0008/), enforced by `flake8` in CI (`.github/workflows/linter.yml`): blocking on `E9`/`F63`/`F7`/`F82` (syntax errors, undefined names), with line length 127 and McCabe complexity 10 as non-blocking warnings. Public-facing modules, classes, and functions carry docstrings.


### PR DESCRIPTION
 Summary of changes
  - frontend/README.md — replaced the create-next-app boilerplate with project-specific install/run, Supabase env vars (with a note that the service-role key must never go in a NEXT_PUBLIC_* var), and the backend dependency
  - scripts/eyetracker/README.md — new backend component README, mirrors the root content for install/run/controls/layout
  - frontend/.env.local.example — placeholder template with a comment warning against putting the service-role key in there
  - .gitignore — added !.env.local.example exception so the template can be committed while real .env.local stays ignored