### PR TITLE
Calibration Update: measure error at periphery and calibrate accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ py -m scripts.eyetracker
 | --- | --- |
 | `c` | Quick calibration (4×3 grid, degree-2 polynomial) |
 | `d` | Detailed calibration (5×4 grid, degree-3 polynomial, with worst-point recapture) |
+| `m` | Multi-pose calibration (one grid per head pose, aggregated into one fit — widens field-of-view coverage; press `c` to start each pose) |
+| `v` | Validation capture (collect-only; writes a held-out session tagged `phase: validation` for accuracy measurement, leaves the live calibration untouched) |
 | `l` | Load most recent saved calibration |
 | `r` | Reset the pye3d 3D pupil model (give it ~30 s to reconverge) |
 | `space` | Pause |
 | `q` | Quit |
+
+For why `m` and `v` exist and how to read the accuracy numbers, see
+[`docs/calibration_coverage.md`](docs/calibration_coverage.md) and
+[`docs/multipose_calibration.md`](docs/multipose_calibration.md).
 
 ## Repo layout
 
@@ -54,7 +60,7 @@ scripts/extras/             # Standalone utilities
     calibrate_scene_intrinsics.py   # ChArUco intrinsics for the scene camera
     generate_charuco_board.py       # Prints the board PNG used above
     gaze_emulator.py                # Synthetic gaze stream for dashboard dev
-    measure_gaze_accuracy.py        # Post-hoc accuracy on a labeled session
+    measure_gaze_accuracy.py        # Accuracy binned by eccentricity; held-out validation sessions
     heatmap.py, camera_test.py, linux_cam_stream.py
 
 experimental/               # Paused / on-hold work, kept for reference
@@ -62,6 +68,8 @@ experimental/               # Paused / on-hold work, kept for reference
 
 docs/                       # Implementation notes, citations, architecture
     polynomial_gaze_mapping.md      # How the pupil→scene fit works end-to-end
+    calibration_coverage.md         # The coverage problem + eccentricity validation tooling
+    multipose_calibration.md        # Multi-pose calibration: widening FOV coverage
     data_collection.md              # Fields the data-collection pipeline captures
     dataset_format.md               # On-disk format for sessions + calibration artifacts
     citations/                      # references.bib + references.tex

--- a/TODO_calibration_ux.md
+++ b/TODO_calibration_ux.md
@@ -1,0 +1,176 @@
+# TODO: Calibration UX feedback (this branch: calibration-update)
+
+Usability fixes for the live calibration overlay — they don't change the fit
+or the data format. Being implemented on the calibration-update branch.
+
+Status: ALL items implemented (2+3 subsumed by 5). Keys: 'c' capture,
+'s' skip, Esc abort, 'p' preview, '['/']'/'{'/'}' exposure, '-'/'=' marker
+white level, 'q' quit.
+
+## Context: how a fixation is captured today
+
+`CalibrationRoutine.update()` (`scripts/eyetracker/calibration/routine.py`, ~L243)
+runs every frame while `is_collecting` is True and **silently early-returns**
+when it can't use the frame:
+
+- `pupil_center is None or eye_frame is None` → no pupil this frame.
+- `scene_frame is None` → no scene cam.
+- `compute_homography(...)` returns `None` → fewer than 4 ArUco markers visible.
+
+Samples only accumulate when none of those fire, until `SampleCollector` reaches
+`CALIB_SAMPLES`. So if pupil detection (or markers) drops out, the point sits
+"collecting" forever with no feedback — the bug below.
+
+The overlay (`scripts/eyetracker/display/tk_overlay.py`, `render()`) currently
+shows marker state only as bottom-of-screen text:
+`color = "#00ff00" if marker_count == 4 else "#ff6060"` (L138–142). The active
+dot is always `fill="red"` (L107–114) regardless of readiness.
+
+## 1. Sample-stall timeout — DONE
+
+**Problem:** if no new samples land for a while (pupil lost, markers dropped),
+the routine gets stuck on the active point indefinitely and the user ends up
+staring at the dot. Holding a fixation that long also corrupts the reading.
+
+**Want:** if no *accepted* sample has been added for **> 5 s** while collecting,
+abort this fixation, reset the collector, drop back to the idle "press 'c'"
+state for the same point, and tell the user to adjust and re-press 'c'.
+
+**Sketch:**
+- Track a `last_sample_ts` (or "collecting started" ts), updated whenever a
+  sample is actually added in `update()`. Reset it in `begin_capture()`.
+- In `update()` (or a per-frame tick), if `is_collecting` and
+  `now - last_sample_ts > CALIB_SAMPLE_TIMEOUT_S`, call the same teardown as a
+  collector reject (`_discard_pending()`, `is_collecting = False`,
+  `collector.reset()`) and print/flag a "timed out — adjust and press 'c'".
+- New config: `CALIB_SAMPLE_TIMEOUT_S = 5.0`.
+- Surface the timeout in the overlay status line so it's visible, not console-only.
+- Decide whether warmup frames count toward the clock (they shouldn't — start the
+  timer after `consume_warmup_frame()` stops returning True).
+
+## 2. Active dot turns green when 4/4 markers detected — DONE via item 5
+
+**Problem:** the user has to glance at the bottom "4/4" text to know it's safe to
+hold still, which itself moves the eyes and spoils the capture.
+
+**Want:** color the **active dot** green when 4/4 markers are detected (ready),
+red otherwise — so readiness is centered on where the eyes already are.
+
+**Sketch:** in `render()`, the active-dot branch (L107–114) chooses `fill` from
+`self.target_mapper.last_marker_count == 4`. Keep the orange "collecting" ring.
+Keep the existing bottom-of-screen marker text too (still useful at a glance).
+
+## 3. Pupil-not-detected warning + dot stays non-green without a pupil — DONE via item 5
+
+**Problem:** during calibration there's no indication when pupil detection has
+dropped out — only markers are surfaced.
+
+**Want:**
+- Warning text (e.g. "Pupil not detected") above the existing "4/4 markers"
+  line whenever the pupil isn't being detected.
+- The active dot must **not** turn green unless *both* 4/4 markers **and** a
+  pupil are present — readiness = markers AND pupil. (Combine with item 2.)
+
+**Sketch / plumbing note:** the overlay currently has no pupil signal — it only
+reads `target_mapper.last_marker_count`. A "pupil detected this frame" flag needs
+to reach the overlay. Cleanest is probably to have the routine/App expose the
+latest pupil-detection state (the same `pupil_center is None` check `update()`
+already does) and have `render()` read it alongside `last_marker_count`. Confirm
+where the pupil pipeline result lives in the App loop before wiring it.
+
+## 4. Bind exposure hotkeys in the Tk overlay — DONE
+
+**Problem:** scene-cam exposure cannot be adjusted during calibration at all.
+`App._handle_key()` (app.py ~L264) handles `[` `]` `{` `}`, but the fullscreen
+Tk overlay has keyboard focus and `tk_overlay.py` L51 only binds `c`/`s`/`q` —
+the bracket presses never reach the app. So "markers blown out mid-calibration"
+is currently unfixable without quitting the overlay.
+
+**Fix:** bind `bracketleft`/`bracketright`/`braceleft`/`braceright` in
+`overlay.open()`, pushing the same chars onto the key queue. `_handle_key`
+already does the rest. Show `exposure_status()` in the overlay status line so
+the nudge is visible without the eye-cam window.
+
+## 5. Two status rings around the active dot (extends items 2+3) — DONE
+
+Supersedes item 2's "dot turns green" rendering (readiness logic unchanged:
+`ready = markers_ok and pupil_ok`).
+
+- **Inner ring** (~r=30): pupil status. Signal = `App.last_pupil_center is not
+  None` (already post conf-gate + jump-gate, so it covers glare/no-IR-filter
+  pupil dropouts). Needs the item-3 plumbing: App stamps a flag onto the
+  routine (or passes a status object) before `render()`.
+- **Outer ring** (~r=40): marker status as **four quadrant arcs**
+  (`canvas.create_arc`), one per corner marker (IDs 0=TL, 1=TR, 2=BR, 3=BL
+  map directly to quadrants). Requires `ArucoHomography.update_marker_count()`
+  to also cache `last_found_ids` (it already computes the set at L74 and
+  discards it).
+- **Peripheral-vision note:** red-vs-green is hard to see at 20°+ eccentricity.
+  Make ready = quiet (dim/absent), failure = loud (thick bright arc) — detect
+  presence/absence, not hue.
+- **Progress arc:** replace the orange collecting ring with an arc,
+  `extent = 360 * samples / CALIB_SAMPLES`, so capture progress is peripheral
+  too.
+- Bottom text can name missing markers ("missing: TL, BR") once
+  `last_found_ids` exists.
+
+## 6. Manual abort key (pairs with item 1's timeout) — DONE (Esc)
+
+Key: Escape (or `a`), bound in the overlay. If `is_collecting`, run the same
+teardown as the CollectorReject branch (routine.py ~L232): `_discard_pending()`,
+`is_collecting = False`, `collector.reset()` — but do NOT advance
+`current_idx`. Back to idle "press 'c'" on the same point. (`s` mid-collect
+skips the point entirely; abort retries it.)
+
+## 7. Camera preview toggle inside the overlay — DONE ('p')
+
+Hotkey `v` toggles a downscaled (~500px wide) scene-cam preview centered on
+the Tk canvas, redrawn each frame while visible.
+
+- Encode as **PPM** (raw, no compression) → `tk.PhotoImage`; PNG per frame is
+  needlessly slow. Keep a reference or Tk garbage-collects the image.
+- Annotate, don't show raw: `cv2.aruco.drawDetectedMarkers` + tint pixels
+  ≥250 red so blown-out regions are obvious. This is the only feedback that
+  diagnoses *specular glare* (exposure/marker-level knobs don't fix glare).
+- Optional eye-frame preview beside it. NB: `last_eye_frame` is deliberately
+  clean for the dataset (app.py copies before the ellipse draw) — keep a
+  separate annotated copy for preview.
+- Showing a bright image mid-fixation ruins that capture; acceptable, this is
+  a between-attempts troubleshooting mode (abort first via item 6).
+
+## 8. ArUco marker white level — DONE ('-'/'=')
+
+Secondary knob for marker blowout (exposure via item 4 is the primary fix,
+but a display-side level persists across sessions instead of being re-tuned
+each time). NB: the IR filter lives on the EYE camera — removing it affects
+Pupil Labs pupil detection only, never scene exposure or marker rendering.
+
+- Config `ARUCO_WHITE_LEVEL` (default 255). In `generate_marker_png()`:
+  `img[img > 127] = white_level`.
+- The quiet-zone rectangle fill (tk_overlay.py L166) must be computed to the
+  SAME grey — a grey marker inside a white quiet zone is worse than either.
+- ArUco detection thresholds adaptively; grey-on-black should detect down to
+  ~100, but verify on this camera.
+- If live-adjustable via hotkey: invalidate the `_photo_images` cache on
+  change.
+
+## Perf note — DONE
+
+ArUco detection used to run twice per 1080p frame during collection. Now
+`ArucoHomography.process_frame()` (App loop) detects once and caches
+corners/ids + `last_found_ids`; the routine solves via `cached_homography()`.
+
+## Note for item 7 (preview key choice)
+
+`v` now starts a validation capture at the top level, but that branch is
+guarded by `not routine.is_active`, so `v` is free *inside* calibration —
+App can route it to the preview toggle when `routine.is_active`. Still,
+consider a different key to avoid user confusion.
+
+## Notes
+- Items 2 and 3 share the "is the dot allowed to be green" logic — implement
+  together: `ready = markers_ok and pupil_ok`. (Item 5 is the rendering of
+  that logic.)
+- All of these are overlay/feedback changes; none should touch the saved data
+  format or the polynomial fit.
+- Suggested build order: 4 (trivial) → 5 → 1+6 (shared teardown) → 7 → 8.

--- a/docs/calibration_coverage.md
+++ b/docs/calibration_coverage.md
@@ -1,0 +1,164 @@
+# Calibration Coverage and Eccentricity Validation
+
+Why the tracker is accurate when you look near the center of your view and worse
+when you look off to the side — how we *measure* that gap, and (in
+[`multipose_calibration.md`](multipose_calibration.md)) how we close it.
+
+This doc assumes you've read [`polynomial_gaze_mapping.md`](polynomial_gaze_mapping.md),
+which explains the pupil→scene polynomial and the ArUco homography. Here we care
+about *where in the user's field of view the fit is trustworthy*, not the fit math.
+
+## The current calibration setup, in one paragraph
+
+The user looks at a grid of red dots drawn on a monitor. Four ArUco markers at the
+screen corners let us compute a per-frame **screen→scene homography**, which turns
+each dot's screen pixel into its location in the scene-camera image. For each dot we
+record one `(pupil_pixel, scene_pixel)` pair — pupil center from the eye camera,
+scene pixel from the homography. After the grid we least-squares-fit a degree-2 or
+degree-3 bivariate polynomial `pupil → scene` (`scripts/eyetracker/gaze/polynomial.py`).
+Two grids ship today: quick (`c`, 4×3, degree 2) and detailed (`d`, 5×4, degree 3,
+with worst-point recapture). Grid sizes, margins, and degrees live in
+`scripts/eyetracker/config.py` under `CALIB_QUICK_*` / `CALIB_DETAILED_*`.
+
+### What it solves
+
+- **Per-subject, per-rig geometry without modeling it.** The eye is a sphere viewed
+  off-axis by the eye camera; the exact pupil→gaze relationship depends on eye shape,
+  camera placement, and how the headset sits. The polynomial learns that relationship
+  empirically from a dozen-ish points, so we never have to measure kappa, eye radius,
+  or camera extrinsics to get a usable gaze estimate.
+- **Head-pose invariance at runtime.** The homography absorbs *where the screen is*
+  during calibration, so the learned polynomial is purely `pupil → scene-cam`, a
+  property of the headset rig. Move your whole body around the room afterward and the
+  polynomial still holds (see the "Mental model" section of the polynomial doc).
+- **Noise averaging.** More fixations than coefficients (e.g. 20 points for 10
+  degree-3 coefficients) means `lstsq` averages out pupil jitter and marker shake
+  instead of memorizing it.
+
+### What it does *not* solve — the coverage problem
+
+Every calibration dot lives on the monitor, and the monitor occupies a small patch
+near the **center** of the scene camera's view. So:
+
+- The **labels** (scene pixels) cluster in a small central region.
+- The **inputs** (pupil positions) only span the eye rotations needed to scan that
+  small region — a narrow band of pupil pixels.
+
+A polynomial is reliable *inside* the cloud of data it was fit on and unreliable
+outside it. When you later look somewhere the calibration never sampled — past the
+edge of where the screen was — the model **extrapolates**, and a degree-3 polynomial's
+cubic terms diverge fast. That is the edge degradation: it is a property of *coverage*,
+not of slippage or hardware.
+
+> A common misread is "just spread the dots wider on the screen." On a normal monitor
+> that barely widens the *pupil* range, because the maximum eye rotation is capped at
+> roughly half the screen's angular width. Widening coverage means getting the eye to
+> rotate further — which is what [multi-pose calibration](multipose_calibration.md)
+> does by moving the head, not the dots.
+
+## Why measure it as *eccentricity*
+
+To know whether a fit is trustworthy "in the center" vs "at the edge," we need a single
+number for "how far off-axis is the user looking." That number is **(optical) eccentricity**: the
+angular distance of a gaze point from the scene camera's optical axis (its principal
+point).
+
+For a point at scene pixel `(u, v)` with camera intrinsics `K`:
+
+```
+r        = hypot(u - cx, v - cy)          # pixels from the principal point
+ecc_deg  = degrees(atan(r / fx))          # angular distance from the optical axis
+```
+
+where `fx = K[0,0]` and `(cx, cy) = (K[0,2], K[1,2])`. See `_eccentricity_deg` in
+`scripts/extras/measure_gaze_accuracy.py`.
+
+Eccentricity is the right axis to bin by, for three reasons:
+
+1. **It's the variable the polynomial extrapolates along.** Error grows with distance
+   from the calibrated cloud, and that cloud is centered on the optical axis. Binning by
+   eccentricity exposes exactly the trend that a single average hides.
+2. **It's resolution- and lens-independent.** "30 px of error" means different things
+   at 720p vs 4K, or with a wide vs narrow lens. Degrees of visual angle are comparable
+   across rigs and are the unit accuracy is quoted in (Pupil Labs Neon is ~0.5–1°).
+3. **It maps onto how the eye actually works.** The scene camera points roughly along
+   head-forward, so scene-frame eccentricity ≈ the eye's rotation away from
+   head-forward — i.e. where in the **oculomotor range** the user is. People turn their
+   *head* to look far off-axis, so in practice gaze rarely exceeds the comfortable
+   oculomotor range (~±20–25°); that range is exactly what we want covered and measured.
+
+   (This is an approximation: it assumes the scene-cam optical axis ≈ head-forward and
+   ignores eye↔scene-camera parallax and target depth. Good enough to rank center vs
+   edge; see "What could be improved.")
+
+## The validation tooling
+
+A single average error over the calibration points is misleading twice over: the points
+are clustered in the center, *and* leave-one-out error only tells you about regions you
+calibrated. Two pieces fix this.
+
+### 1. Held-out capture — the `v` key
+
+`v` runs the same grid as the detailed calibration but in **collect-only** mode: it
+fits nothing and never touches the live `calibration_pupil.npz` or the in-memory mapper
+(`CalibrationRoutine(fit_on_finish=False)` in `scripts/eyetracker/calibration/routine.py`).
+On finish it writes the captured `(pupil, scene)` median pairs to a timestamped
+`validation_<ts>.npz` (`save_validation` in `calibration/persistence.py`).
+
+The point: capture a `v` set **at a steep head angle** so its gaze points land at high
+eccentricity — out where the calibration never sampled. That gives you ground-truth
+pairs the fit has never seen, in the region you most want to test.
+
+### 2. Eccentricity-binned measurement
+
+`python -m scripts.extras.measure_gaze_accuracy [--val validation_*.npz]` refits the
+polynomial from a saved calibration and reports error binned by eccentricity:
+
+- **In-sample**, using **leave-one-out** error (refit without each point, predict it).
+  LOO is used here because these points *were* in the fit; training residuals would
+  flatter the fit by measuring how well it memorized its own labels.
+- **Held-out**, using the **plain full-data fit** to predict each `--val` point. No LOO
+  needed — the validation points were never in the fit, so there's no leakage.
+- A **coverage report**: the pupil-pixel range and the eccentricity histogram of the
+  calibration labels, so under-coverage is visible before you even look at error.
+
+### Reading the output
+
+A sample run on a head-on detailed calibration (no `--val` yet):
+
+```
+Coverage (fit set):
+  pupil x:   269.0 ..   377.0 px   y:   211.0 ..   267.0 px
+  gaze eccentricity: 2.0° .. 24.5°   [0-5°:1  5-10°:5  10-15°:6  15-20°:7  >20°:1]
+
+In-sample LOO error by eccentricity:
+      band    n      mean   mean°       max    max°
+      0-5°    1     9.8px   0.30°     9.8px   0.30°
+     5-10°    5    11.3px   0.34°    17.6px   0.53°
+    10-15°    6    18.5px   0.56°    32.7px   0.99°
+    15-20°    7    23.9px   0.72°    73.1px   2.21°
+      >20°    1    35.8px   1.08°    35.8px   1.08°
+   overall   20    19.0px   0.58°    73.1px   2.21°
+```
+
+Two things to notice. First, the **pupil range is tiny** (≈108 px wide, ≈56 px tall) —
+the eye barely moved during calibration. Second, error **climbs monotonically with
+eccentricity** (0.30° at center → 0.72° by 15–20°), even *within* the calibrated region.
+Add a wide-angle `--val` set and the outer bins blow up further, because that's pure
+extrapolation. That growth curve, not the single "overall" number, is the thing to drive
+down.
+
+## What could be improved
+
+- **Eccentricity is an approximation to true gaze angle.** It's measured in the scene-cam
+  frame relative to the principal point, assuming the scene cam looks along head-forward
+  and ignoring eye↔scene parallax and target depth. With the planned extrinsics jig (see
+  `docs/data_collection.md`) and a depth estimate, this could become a true
+  eye-relative visual angle.
+- **The polynomial itself is the ceiling.** Widening coverage fixes catastrophic
+  extrapolation but a global low-degree polynomial has fixed capacity — fitting a wider,
+  more nonlinear domain can trade a little center accuracy for the edges. The real fix is
+  higher-capacity or local models, ultimately the planned image-to-gaze approach, which
+  this richer, eccentricity-spanning data collection is meant to feed.
+- **Validation labels still ride on the ArUco homography**, so a steep-angle `v` set is
+  only as good as marker detection at that angle (all four corners must stay in frame).

--- a/docs/loo_error_notes.md
+++ b/docs/loo_error_notes.md
@@ -1,0 +1,114 @@
+# Leave-one-out (LOO) error — notes, past regression, and caveats
+
+Working notes on the calibration LOO error: what it's for, a regression that
+briefly broke it, and the caveats that are still live. For the conceptual
+mapper/LOO walkthrough see [polynomial_gaze_mapping.md](polynomial_gaze_mapping.md).
+
+## Status (2026-06-29)
+
+**LOO is currently implemented correctly.** `PolynomialGazeMapper.fit()`
+(`scripts/eyetracker/gaze/polynomial.py:52`) computes a real leave-one-out error
+in the loop at lines ~79-88. A quick check confirms it returns non-zero errors on
+noisy data (see the regression test at the bottom). This doc is a record so the
+regression below doesn't silently return.
+
+## What LOO is and why it matters here
+
+For each calibration point *i*: refit the polynomial on the other *n*−1 points,
+predict the held-out point *i*, and measure the reprojection error in scene-cam
+pixels. Averaged (and max'd) over all *n* points, plus a per-point array.
+
+It's used for three things — none of which affect the live fit/predict (those use
+the full-data `lstsq` coefficients), but all of which are calibration *quality*
+machinery:
+
+1. **Recapture targeting** — the detailed routine's two-pass mode picks the
+   worst-N fixations to re-prompt via `np.argsort(per_point_errs)`
+   (`scripts/eyetracker/calibration/routine.py:435`).
+2. **Quality reporting + warning gate** — `_report_and_save` prints
+   `LOO error: avg/max` (`routine.py:472`) and warns if `loo_avg_err` exceeds
+   ~4% of scene width (`routine.py:478-480`).
+3. **Accuracy measurement** — `scripts/extras/measure_gaze_accuracy.py:157-185`
+   reports avg/max/per-point LOO in px and degrees.
+
+(`persistence.py` does **not** record LOO metrics — it saves the polynomial
+coefficients via `state_dict`. So a LOO regression does not corrupt saved
+calibrations, only the reporting/recapture.)
+
+## The regression that happened
+
+At one point `fit()` was reduced to a stub:
+
+```python
+errors = np.zeros(n)          # <-- the real refit loop had been removed
+return FitReport(..., loo_avg_err=0.0, loo_max_err=0.0, per_point_errs=errors)
+```
+
+It slipped in during the degree-2/3 refactor: the intent (a `TODO` at the top of
+the file) was to replace the O(n) refit loop with the hat-matrix shortcut, but
+only the zeros stub landed and got committed. The fit itself stayed correct, so
+tracking worked — the breakage was invisible except in the quality machinery.
+
+### Blast radius while stubbed
+
+- **Recapture re-prompted the wrong points.** `np.argsort([0,0,…,0])` is
+  `[0,1,…,n-1]`, so "worst N" was always the *last* N captured fixations
+  (row-major → bottom-right of the grid), regardless of actual error. Two-pass
+  refinement was effectively choosing arbitrary points. Note `_should_run_pass_two`
+  guards on `per_point_errs is None`, but a zeros array isn't `None`, so pass two
+  still ran — on garbage selection.
+- **Reported accuracy was a lie** — every calibration printed `avg=0.0px,
+  max=0.0px`.
+- **The high-error warning was dead** — `0 > err_threshold` is never true.
+- **`measure_gaze_accuracy.py` reported 0.000px / 0.00°** and all-zero per-point
+  errors. Any ~0.39° figure on record predates the stub.
+
+## The fix (now in place)
+
+The explicit refit loop, degree-agnostic (uses the design matrix `A` as built):
+
+```python
+errors = np.zeros(n)
+for i in range(n):
+    A_loo = np.delete(A, i, axis=0)
+    cx_loo, *_ = np.linalg.lstsq(A_loo, np.delete(bx, i), rcond=None)
+    cy_loo, *_ = np.linalg.lstsq(A_loo, np.delete(by, i), rcond=None)
+    errors[i] = math.hypot(A[i] @ cx_loo - bx[i], A[i] @ cy_loo - by[i])
+```
+
+## Remaining caveats (still live)
+
+1. **LOO is meaningless when `n == k`** (`k` = feature count: 6 for degree 2, 10
+   for degree 3). The refit drops to `n−1 = k−1` rows < `k` columns →
+   underdetermined; `lstsq` returns a min-norm solution (no crash) but the LOO
+   number is junk. `fit()` only guards `n >= k`, so LOO is only trustworthy at
+   `n >= k + 1`. The configured grids are all comfortably above this (quick 9-12
+   vs 6, detailed 20 vs 10, multipose 3×12 vs 10), and `_should_run_pass_two`
+   keeps `n` above the minimum after a recapture drop — so it doesn't bite today.
+   If a smaller grid is ever configured, consider skipping LOO (leave zeros) when
+   `n <= k` rather than reporting a misleading value.
+
+2. **Performance: O(n) refits.** Each `fit()` does `2n` extra `lstsq` solves.
+   For n ≤ ~36 this is microseconds — not worth optimizing now. The closed-form
+   alternative (the old `TODO`) uses the hat matrix `H = A (AᵀA)⁻¹ Aᵀ`: the LOO
+   residual is `residual_i / (1 − h_ii)`, so one fit + the leverages `h_ii` gives
+   all per-point LOO errors with no refitting. Revisit only if grids get large.
+
+## Guard against recurrence
+
+A minimal regression test (LOO must be non-zero on noisy quadratic data):
+
+```python
+import numpy as np
+from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
+
+rng = np.random.default_rng(0)
+pupil = rng.uniform(-1, 1, (12, 2))
+scene = np.column_stack([
+    3 + 2*pupil[:, 0] - pupil[:, 1] + 0.5*pupil[:, 0]**2,
+    1 - pupil[:, 0] + 2*pupil[:, 1] + 0.3*pupil[:, 1]**2,
+]) + rng.normal(0, 0.05, (12, 2))
+
+rep = PolynomialGazeMapper(degree=2).fit(pupil, scene)
+assert rep.loo_avg_err > 0 and np.any(rep.per_point_errs > 0), "LOO is stubbed!"
+```

--- a/docs/multipose_calibration.md
+++ b/docs/multipose_calibration.md
@@ -1,0 +1,132 @@
+# Multi-Pose Calibration
+
+How we widen the calibrated region of the field of view so gaze stays accurate when
+the user looks off-center — the fix for the coverage problem described in
+[`calibration_coverage.md`](calibration_coverage.md).
+
+## The problem, recapped
+
+A normal head-on calibration only samples a narrow band of eye rotations: every dot is
+on a monitor that fills a small patch near the center of the scene camera's view. The
+pupil→scene polynomial is then trustworthy only inside that small central cloud and
+extrapolates badly outside it. We want to extend the cloud toward the full comfortable
+oculomotor range (~±20–25°) without buying a bigger screen.
+
+## The mechanism: move the head, not the dots
+
+The key fact (same one that makes the polynomial head-pose invariant at runtime) is that
+the scene camera is **head-mounted**, so the pupil→scene mapping is *head-relative*.
+
+Rotate your **head** ~30° away from the screen but keep fixating the dots, and two things
+happen at once:
+
+- The screen now lands near the **edge** of the scene-camera frame, so the homography
+  places the labels at high eccentricity.
+- Your eye must rotate ~30° to keep fixating, so the **pupil** moves into a position a
+  head-on calibration never reaches.
+
+Both the input cloud (pupil) and the output cloud (scene pixels) extend together. The
+control variable is **head orientation relative to the target**, not screen tilt — and
+it reaches eye rotations that are simply unavailable when the screen sits dead-center
+(where max eye rotation ≈ half the screen's angular width).
+
+### Why discrete static poses, not continuous motion
+
+Capture must happen while the head is **still**. The per-fixation gate
+(`SampleCollector` in `scripts/eyetracker/calibration/collector.py`) rejects a fixation
+if the scene label drifts more than `CALIB_SCENE_STD_THRESH` px ("Head may have moved").
+That gate is correct and we keep it. So the routine is a sequence of **static poses**:
+reposition the head → hold still → run a grid → reposition → next pose. Continuous
+"look around while moving" would both trip the gate and desync the eye/scene cameras
+(the pupil frame and the homography label would come from slightly different instants),
+injecting label noise that scales with motion speed.
+
+Do all poses in **one session without removing or adjusting the headset**, so headset
+slippage doesn't drift between poses — every pose then samples the same pupil→scene map.
+
+## The routine
+
+Press **`m`** to start. Multi-pose reuses the existing grid + homography + collector; the
+only new behavior is a loop over poses that accumulates into a single fit
+(`CalibrationRoutine` with `num_poses > 1`, in `scripts/eyetracker/calibration/routine.py`).
+
+Flow:
+
+1. **Pose 1** is captured exactly like a normal grid. The overlay shows `Pose 1/5` and
+   per-pose guidance.
+2. When the grid completes and poses remain, the routine enters a **pose break**
+   (`_begin_pose_break`): it stops collecting and the overlay shows the next pose's
+   instruction (e.g. "turn your head LEFT") plus the live `aruco: N/4 markers visible`
+   readout. Captured points are **not** cleared.
+3. The user repositions and presses **`c`** to start the next pose (`begin_next_pose`):
+   the same grid is re-armed, `current_idx` resets, but the accumulated buffers carry
+   over.
+4. After the **final** pose, all `(pupil, scene)` pairs across every pose feed one
+   `lstsq` fit (the existing `_finish` path).
+
+So 5 poses × a 12-point grid → ~60 points feeding one degree-3 fit, spanning a much wider
+slice of the oculomotor range than 20 head-on points.
+
+Two-pass **recapture is disabled** in multi-pose (`recapture_worst_n = 0`). Recapture
+re-prompts the worst points, but "the worst point" came from a specific head pose; redoing
+it at whatever pose the user happens to be in would be ambiguous.
+
+### Configuration
+
+In `scripts/eyetracker/config.py`:
+
+| Constant | Meaning |
+| --- | --- |
+| `CALIB_POSES` | number of head poses (default 5: head-on, left, right, down, up) |
+| `CALIB_MULTIPOSE_ROWS` / `_COLS` / `_MARGIN` | grid per pose (default 4×3, margin 180) |
+| `CALIB_MULTIPOSE_DEGREE` | polynomial degree (default 3 — plenty of points to support it) |
+| `CALIB_POSE_GUIDANCE` | per-pose instruction strings shown on the overlay |
+
+`next_pose_guidance()` falls back to a generic prompt if you raise `CALIB_POSES` beyond
+the number of guidance strings, so the two can be tuned independently.
+
+### Practical limits
+
+- **ArUco visibility bounds the pose.** At steep angles the screen rotates toward the
+  edge of the scene frame and a corner marker can drop out. The existing "not all 4
+  markers visible" guard simply won't capture until all four are back — the `aruco: N/4`
+  readout tells the user when a pose is too extreme.
+- **Oculomotor comfort bounds it too.** Beyond ~±25° of eye rotation fixation gets
+  uncomfortable and unstable; that's also roughly where real users start turning their
+  head instead, so it's a sensible ceiling rather than a limitation to fight.
+
+## What it improves (and what it can't)
+
+- **Improves:** the *usable* field of view. Outer-eccentricity error should drop sharply
+  because those regions are now interpolation instead of extrapolation. It also enriches
+  the per-session image dataset (eye + scene frames are saved per sample regardless), so
+  the future image-to-gaze model gets training data spanning the full oculomotor range —
+  the main motivation.
+- **Can't:** raise the polynomial's *center* ceiling. A global degree-3 fit has fixed
+  capacity; spreading data over a wider, more nonlinear domain may trade a little
+  peak-center accuracy for the edges. Lifting the ceiling needs a higher-capacity or
+  local model — the planned image-to-gaze pivot.
+
+## Verifying it worked
+
+Multi-pose is exactly the kind of change that needs the
+[eccentricity validation tooling](calibration_coverage.md#the-validation-tooling) to
+confirm — "feels better" isn't measurable. End-to-end:
+
+1. Capture a held-out wide-angle set once with `v` (steep head angle). Keep this
+   `validation_<ts>.npz` fixed so it's a fair yardstick across runs.
+2. Measure your **current head-on** calibration against it:
+   `python -m scripts.extras.measure_gaze_accuracy --val scripts/eyetracker/validation_*.npz`
+   — expect large error in the outer eccentricity bins (the gap).
+3. Recalibrate with `m` across all poses (don't touch the headset), confirming LOO stays
+   under the usable threshold (`0.04 × scene_width`).
+4. Re-measure against the same `--val` set. The outer bins should drop substantially.
+   Watch the center bin too, to quantify any trade-off.
+
+## Future direction
+
+Multi-pose reuses the screen + ArUco rig, so coverage is still bounded by screen size and
+marker visibility. A more scalable rig for the model dataset is **world-fixed fiducials**
+— a printed ArUco wall or poster — letting targets span the full scene FOV independently
+of any screen, and dovetailing with the planned extrinsics jig. That's deliberately out
+of scope here; multi-pose is the no-new-hardware step.

--- a/scripts/extras/measure_gaze_accuracy.py
+++ b/scripts/extras/measure_gaze_accuracy.py
@@ -1,30 +1,48 @@
-"""Recompute gaze tracker accuracy from a saved session.
+"""Recompute gaze tracker accuracy from saved calibration sessions.
 
 Loads a `session_<ts>/` (metadata.json for scene intrinsics + sizes, labels.csv
 for the captured samples), refits the polynomial (deterministic — same lstsq as
-live calibration), and prints LOO error in both pixels and degrees, plus a
-per-point breakdown.
+live calibration), and reports error in pixels and degrees. Two views:
+
+- In-sample: leave-one-out error over the fit points, binned by eccentricity
+  (angular distance from the scene-cam principal point). Because head-on
+  calibration clusters points near scene-center, the inner bins dominate.
+- Held-out: pass one or more validation session dirs (captured with 'v', tagged
+  `phase: validation`, ideally at steep head angles). The fit is evaluated on
+  data it never saw, binned by eccentricity — this is what quantifies accuracy
+  *outside* the calibrated region. A validation session is a normal session with
+  labels.csv but no fit, so it loads exactly like a calibration one.
 
 The fit uses the per-fixation median of the raw labels.csv rows, which closely
 tracks the live-calibration fit (live uses the median of inlier samples; this
 uses the median of all collected samples, so numbers can differ slightly).
 
-Useful for:
-- Checking accuracy of past calibration sessions without re-running.
-- Spotting bad fixations (sort by error -> outliers float to the top).
-- Tracking accuracy over time after hardware/config changes.
+Camera intrinsics use the standard OpenCV symbols (read from the session's
+metadata.json, which inlines the scene-cam intrinsics); they recur below:
+    K       3x3 camera intrinsic matrix.
+    fx      focal length in pixels, K[0][0].
+    cx, cy  principal point in pixels, K[0][2] / K[1][2] — the pixel the optical
+            axis pierces, i.e. "straight ahead" in the scene image. Eccentricity
+            is measured outward from here.
 
 Run:  python -m scripts.extras.measure_gaze_accuracy [--session <dir>]
-      (default: the most recent session under data/calibration/)
+      python -m scripts.extras.measure_gaze_accuracy --val data/calibration/session_<ts>
+      (--session default: the most recent session under data/calibration/)
 """
 import argparse
 import datetime
 import math
 import sys
 
+import numpy as np
+
 from scripts.eyetracker.calibration.paths import dataset_root
 from scripts.eyetracker.dataset import load_session, session_dirs
 from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
+
+
+# Eccentricity bin edges in degrees; last bin is open-ended.
+ECCENTRICITY_BIN_EDGES = [0.0, 5.0, 10.0, 15.0, 20.0, float("inf")]
 
 
 def _resolve_session(arg: str) -> str:
@@ -36,66 +54,166 @@ def _resolve_session(arg: str) -> str:
     return dirs[-1]
 
 
+def _load_fixation_medians(session_dir: str):
+    """Load a session and collapse its labels.csv to one row per fixation (the
+    median of that fixation's samples, matching the live fit). Returns
+    (metadata, pupil_vectors, scene_points, screen_points); metadata is None for
+    legacy sessions with no metadata.json."""
+    metadata, df = load_session(session_dir)
+    grouped = df.groupby("fixation_id").median(numeric_only=True)
+    pupil_vectors = grouped[["pupil_x", "pupil_y"]].to_numpy(dtype=float)
+    scene_points = grouped[["scene_target_x", "scene_target_y"]].to_numpy(dtype=float)
+    screen_points = grouped[["x_screen", "y_screen"]].to_numpy(dtype=float)
+    return metadata, pupil_vectors, scene_points, screen_points
+
+
+def _scene_intrinsics(metadata: dict, session_dir: str):
+    """Return (fx, cx, cy) from a session's inlined scene intrinsics, or exit
+    with a message if the session lacks them."""
+    scene_intr = (metadata.get("intrinsics") or {}).get("scene") if metadata else None
+    if not scene_intr or scene_intr.get("K") is None:
+        sys.exit(f"{session_dir} has no scene intrinsics. Run "
+                 "scripts.extras.calibrate_scene_intrinsics first.")
+    K = scene_intr["K"]
+    return float(K[0][0]), float(K[0][2]), float(K[1][2])
+
+
+def _bin_label(bin_index: int) -> str:
+    low, high = ECCENTRICITY_BIN_EDGES[bin_index], ECCENTRICITY_BIN_EDGES[bin_index + 1]
+    return f">{low:g}°" if high == float("inf") else f"{low:g}-{high:g}°"
+
+
+def _bin_index(eccentricity_deg: float) -> int:
+    for i in range(len(ECCENTRICITY_BIN_EDGES) - 1):
+        if ECCENTRICITY_BIN_EDGES[i] <= eccentricity_deg < ECCENTRICITY_BIN_EDGES[i + 1]:
+            return i
+    return len(ECCENTRICITY_BIN_EDGES) - 2
+
+
+def _eccentricity_deg(scene_points: np.ndarray, fx: float,
+                      cx: float, cy: float) -> np.ndarray:
+    """Angular distance (degrees) of each scene point from the principal point
+    (cx, cy), via the pinhole model with focal length fx in pixels."""
+    radius_px = np.hypot(scene_points[:, 0] - cx, scene_points[:, 1] - cy)
+    return np.degrees(np.arctan(radius_px / fx))
+
+
+def _predict_errors(mapper: PolynomialGazeMapper,
+                    pupil: np.ndarray, scene: np.ndarray) -> np.ndarray:
+    """Pixel error between predicted and labelled scene point per sample."""
+    pred_pts = np.array([mapper.predict((float(p[0]), float(p[1]))) for p in pupil])
+    return np.hypot(pred_pts[:, 0] - scene[:, 0], pred_pts[:, 1] - scene[:, 1])
+
+
+def _print_eccentricity_table(title: str, eccentricity_deg: np.ndarray,
+                              errors_px: np.ndarray, fx: float) -> None:
+    """Print mean/max error per eccentricity band. fx (focal length, px)
+    converts pixel error to degrees."""
+    print(title)
+    print(f"  {'band':>8} {'n':>4} {'mean':>9} {'mean°':>7} "
+          f"{'max':>9} {'max°':>7}")
+    errors_px = np.asarray(errors_px, dtype=float)
+    for i in range(len(ECCENTRICITY_BIN_EDGES) - 1):
+        in_band = np.array([_bin_index(angle) == i for angle in eccentricity_deg])
+        count = int(in_band.sum())
+        if count == 0:
+            continue
+        band_errors = errors_px[in_band]
+        mean_deg = math.degrees(math.atan(float(band_errors.mean()) / fx))
+        max_deg = math.degrees(math.atan(float(band_errors.max()) / fx))
+        print(f"  {_bin_label(i):>8} {count:>4} {band_errors.mean():>7.1f}px {mean_deg:>6.2f}° "
+              f"{band_errors.max():>7.1f}px {max_deg:>6.2f}°")
+    mean_deg = math.degrees(math.atan(float(errors_px.mean()) / fx))
+    max_deg = math.degrees(math.atan(float(errors_px.max()) / fx))
+    print(f"  {'overall':>8} {len(errors_px):>4} {errors_px.mean():>7.1f}px "
+          f"{mean_deg:>6.2f}° {errors_px.max():>7.1f}px {max_deg:>6.2f}°")
+    print()
+
+
+def _coverage_report(pupil_vectors: np.ndarray, scene_points: np.ndarray,
+                     fx: float, cx: float, cy: float) -> None:
+    """Print pupil-pixel span and the eccentricity histogram of the fit set.
+    fx / (cx, cy) are the focal length and principal point (see module doc)."""
+    print("Coverage (fit set):")
+    print(f"  pupil x: {pupil_vectors[:, 0].min():7.1f} .. {pupil_vectors[:, 0].max():7.1f} px"
+          f"   y: {pupil_vectors[:, 1].min():7.1f} .. {pupil_vectors[:, 1].max():7.1f} px")
+    eccentricity = _eccentricity_deg(scene_points, fx, cx, cy)
+    counts = np.zeros(len(ECCENTRICITY_BIN_EDGES) - 1, dtype=int)
+    for angle in eccentricity:
+        counts[_bin_index(angle)] += 1
+    histogram = "  ".join(f"{_bin_label(i)}:{counts[i]}"
+                          for i in range(len(counts)) if counts[i])
+    print(f"  gaze eccentricity: {eccentricity.min():.1f}° .. {eccentricity.max():.1f}°   [{histogram}]")
+    print()
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--session", default=None,
-                        help="session dir to analyze (default: most recent)")
+                        help="calibration session dir to analyze "
+                             "(default: most recent under data/calibration/)")
+    parser.add_argument("--val", nargs="*", default=[],
+                        help="held-out validation session dir(s) to evaluate the "
+                             "fit against (captured with 'v'; globs allowed).")
     args = parser.parse_args()
 
     session = _resolve_session(args.session)
-    metadata, df = load_session(session)
+    metadata, pupil_vectors, scene_points, screen_points = _load_fixation_medians(session)
     if metadata is None:
         sys.exit(f"{session} has no metadata.json (legacy session) — "
                  "cannot read scene intrinsics.")
-    scene_intr = (metadata.get("intrinsics") or {}).get("scene")
-    if not scene_intr or scene_intr.get("K") is None:
-        sys.exit("Session has no scene intrinsics. Run "
-                 "scripts.extras.calibrate_scene_intrinsics first.")
-
-    fx = float(scene_intr["K"][0][0])
-    sw = int(metadata["scene_cam"]["width"])
-    sh = int(metadata["scene_cam"]["height"])
-    ts = datetime.datetime.fromtimestamp(float(metadata["timestamp"]))
+    fx, cx, cy = _scene_intrinsics(metadata, session)
+    scene_width = int(metadata["scene_cam"]["width"])
+    scene_height = int(metadata["scene_cam"]["height"])
+    session_time = datetime.datetime.fromtimestamp(float(metadata["timestamp"]))
     degree = int((metadata.get("fit") or {}).get("degree", 2))
 
-    # Per-fixation median (one point per target), matching the live fit.
-    grouped = df.groupby("fixation_id").median(numeric_only=True)
-    V = grouped[["pupil_x", "pupil_y"]].to_numpy(dtype=float)
-    S = grouped[["scene_target_x", "scene_target_y"]].to_numpy(dtype=float)
-    SP = grouped[["x_screen", "y_screen"]].to_numpy(dtype=float)
-
-    print("=" * 68)
+    print("=" * 72)
     print(f"Session:             {metadata['session_id']}")
-    print(f"Captured:            {ts}")
-    print(f"Scene resolution:    {sw}x{sh}")
-    print(f"fx (from intr):      {fx:.2f} px")
+    print(f"Captured:            {session_time}")
+    print(f"Scene resolution:    {scene_width}x{scene_height}")
+    print(f"fx / principal:      {fx:.1f} px / ({cx:.1f}, {cy:.1f})")
     print(f"Polynomial degree:   {degree}")
     print()
-    print(f"scene_points x range: {float(S[:, 0].min()):7.1f} .. {float(S[:, 0].max()):7.1f}  "
-          f"({(S[:, 0].max() - S[:, 0].min()) / sw * 100:.1f}% of frame width)")
-    print(f"scene_points y range: {float(S[:, 1].min()):7.1f} .. {float(S[:, 1].max()):7.1f}  "
-          f"({(S[:, 1].max() - S[:, 1].min()) / sh * 100:.1f}% of frame height)")
-    print()
 
-    report = PolynomialGazeMapper(degree=degree).fit(V, S)
+    _coverage_report(pupil_vectors, scene_points, fx, cx, cy)
+
+    mapper = PolynomialGazeMapper(degree=degree)
+    report = mapper.fit(pupil_vectors, scene_points)
     avg_deg = math.degrees(math.atan(report.loo_avg_err / fx))
     max_deg = math.degrees(math.atan(report.loo_max_err / fx))
-    print(f"n_points:  {report.n_points}")
-    print(f"LOO avg:   {report.loo_avg_err:7.3f} px   ->  {avg_deg:.4f}°")
-    print(f"LOO max:   {report.loo_max_err:7.3f} px   ->  {max_deg:.4f}°")
-    print()
+    print(f"In-sample LOO over {report.n_points} fit points: "
+          f"avg {report.loo_avg_err:.1f}px ({avg_deg:.2f}°), "
+          f"max {report.loo_max_err:.1f}px ({max_deg:.2f}°)")
+    eccentricity_fit = _eccentricity_deg(scene_points, fx, cx, cy)
+    _print_eccentricity_table("In-sample LOO error by eccentricity:",
+                              eccentricity_fit, report.per_point_errs, fx)
 
-    print("Per-point error (sorted worst → best):")
+    # Evaluate the (full-data) fit against any held-out validation sessions.
+    for val_session in args.val:
+        _, val_pupil, val_scene, _ = _load_fixation_medians(val_session)
+        errors = _predict_errors(mapper, val_pupil, val_scene)
+        eccentricity = _eccentricity_deg(val_scene, fx, cx, cy)
+        print("-" * 72)
+        print(f"Held-out validation: {val_session} ({len(val_pupil)} points)")
+        _print_eccentricity_table("Held-out error by eccentricity:",
+                                  eccentricity, errors, fx)
+
+    if not args.val:
+        print("(no --val sessions given; pass a validation session dir to "
+              "measure held-out / wide-angle accuracy)")
+
+    print("Worst in-sample points (sorted worst → best):")
     print(f"  {'pt':>3} {'px':>9} {'deg':>8}   screen_px         pupil_px")
-    errs = report.per_point_errs
-    order = sorted(range(len(errs)), key=lambda i: -errs[i])
-    for i in order:
-        e_px = float(errs[i])
-        e_deg = math.degrees(math.atan(e_px / fx))
-        sp = tuple(int(x) for x in SP[i])
-        vv = (float(V[i, 0]), float(V[i, 1]))
-        print(f"  {i:>3} {e_px:>9.2f} {e_deg:>7.3f}°   {sp}   ({vv[0]:.1f}, {vv[1]:.1f})")
-    print("=" * 68)
+    point_errors = report.per_point_errs
+    order = sorted(range(len(point_errors)), key=lambda i: -point_errors[i])
+    for i in order[:10]:
+        error_px = float(point_errors[i])
+        error_deg = math.degrees(math.atan(error_px / fx))
+        screen_pt = tuple(int(x) for x in screen_points[i])
+        pupil_pt = (float(pupil_vectors[i, 0]), float(pupil_vectors[i, 1]))
+        print(f"  {i:>3} {error_px:>9.2f} {error_deg:>7.3f}°   {screen_pt}   ({pupil_pt[0]:.1f}, {pupil_pt[1]:.1f})")
+    print("=" * 72)
 
 
 if __name__ == "__main__":

--- a/scripts/eyetracker/__main__.py
+++ b/scripts/eyetracker/__main__.py
@@ -29,6 +29,12 @@ from scripts.eyetracker.config import (
     CALIB_DETAILED_RECAPTURE_WORST,
     CALIB_DETAILED_ROWS,
     CALIB_INLIERS,
+    CALIB_MULTIPOSE_COLS,
+    CALIB_MULTIPOSE_DEGREE,
+    CALIB_MULTIPOSE_MARGIN,
+    CALIB_MULTIPOSE_ROWS,
+    CALIB_POSES,
+    CALIB_VALIDATION_DEGREE,
     CALIB_QUICK_COLS,
     CALIB_QUICK_DEGREE,
     CALIB_QUICK_MARGIN,
@@ -107,6 +113,28 @@ def _build_app(eye_index: int) -> App:
         recapture_worst_n=CALIB_DETAILED_RECAPTURE_WORST,
         label="detailed calibration",
     )
+    multipose_routine = CalibrationRoutine(
+        pattern=GridPattern(rows=CALIB_MULTIPOSE_ROWS, cols=CALIB_MULTIPOSE_COLS,
+                            margin=CALIB_MULTIPOSE_MARGIN),
+        collector=SampleCollector(**collector_kwargs),
+        target_mapper=target_mapper,
+        mapper=mapper,
+        mapper_degree=CALIB_MULTIPOSE_DEGREE,
+        recapture_worst_n=0,  # pose-ambiguous; disabled in multi-pose
+        num_poses=CALIB_POSES,
+        label="multi-pose calibration",
+    )
+    validation_routine = CalibrationRoutine(
+        pattern=GridPattern(rows=CALIB_DETAILED_ROWS, cols=CALIB_DETAILED_COLS,
+                            margin=CALIB_DETAILED_MARGIN),
+        collector=SampleCollector(**collector_kwargs),
+        target_mapper=target_mapper,
+        mapper=mapper,
+        mapper_degree=CALIB_VALIDATION_DEGREE,
+        recapture_worst_n=0,
+        fit_on_finish=False,  # collect-only; never touches the live fit
+        label="validation",
+    )
     return App(
         eye_cam=eye_cam,
         scene_cam=scene_cam,
@@ -121,6 +149,8 @@ def _build_app(eye_index: int) -> App:
         target_mapper=target_mapper,
         quick_routine=quick_routine,
         detailed_routine=detailed_routine,
+        multipose_routine=multipose_routine,
+        validation_routine=validation_routine,
         overlay=TkCalibrationOverlay(target_mapper=target_mapper),
         display=CvDisplay(with_scene=True),
     )

--- a/scripts/eyetracker/app.py
+++ b/scripts/eyetracker/app.py
@@ -78,7 +78,11 @@ class App:
         # Per-frame mutable state, all owned by the App instance.
         self.last_pupil_center: Optional[np.ndarray] = None
         self.last_confidence: float = 0.0
+        # last_eye_frame is the CLEAN crop (saved into the dataset);
+        # last_eye_frame_annotated has the pupil ellipse / status drawings
+        # and feeds the display + the calibration preview.
         self.last_eye_frame: Optional[np.ndarray] = None
+        self.last_eye_frame_annotated: Optional[np.ndarray] = None
         self.last_scene_frame: Optional[np.ndarray] = None
         self._last_gate_log_ts: float = 0.0
 
@@ -105,7 +109,10 @@ class App:
               "'l' = load calibration, 'r' = reset pupil 3D model, "
               "'q' = quit, space = pause")
         print("Scene exposure: '[' / ']' = darker / brighter (fine), "
-              "'{' / '}' = darker / brighter (coarse)")
+              "'{' / '}' = darker / brighter (coarse) — also works during "
+              "calibration")
+        print("During calibration: Esc = abort the current point and retry, "
+              "'p' = camera preview, '-' / '=' = marker brightness")
 
         try:
             self._loop()
@@ -151,7 +158,9 @@ class App:
                 ext_frame = self.scene_cam.read()
                 if ext_frame is not None:
                     self.last_scene_frame = ext_frame.copy()
-                    self.target_mapper.update_marker_count(self.last_scene_frame)
+                    # One ArUco detection per frame, cached — the routine's
+                    # tick() reuses it via cached_homography().
+                    self.target_mapper.process_frame(self.last_scene_frame)
 
                     gaze_xy = None
                     if self.mapper.is_fitted() and not self.routine.is_active:
@@ -159,6 +168,11 @@ class App:
                     self.display.show_scene(ext_frame, gaze_xy)
 
             if self.routine.is_active and self.overlay.is_open():
+                self.overlay.exposure_status = self._exposure_overlay_text()
+                self.overlay.pupil_ok = self.last_pupil_center is not None
+                if self.overlay.preview_enabled:
+                    self.overlay.preview_scene = self._annotated_scene_preview()
+                    self.overlay.preview_eye = self._eye_preview()
                 self.overlay.render(self.routine)
                 self.overlay.pump()
 
@@ -229,7 +243,39 @@ class App:
             cv2.putText(frame, exposure_text, (10, 38),
                         cv2.FONT_HERSHEY_SIMPLEX, 0.45, (255, 255, 0), 1)
 
+        self.last_eye_frame_annotated = frame
         self.display.show_eye(frame)
+
+    def _annotated_scene_preview(self, max_width: int = 560
+                                 ) -> Optional[np.ndarray]:
+        """Scene-cam view for the calibration overlay preview: clipped
+        (blown-out) pixels tinted solid red, detected markers outlined,
+        downscaled. The tint is applied before the outlines so a marker
+        drowning in bloom shows red with no green box around it."""
+        if self.last_scene_frame is None:
+            return None
+        preview = self.last_scene_frame.copy()
+        clipped = preview.max(axis=2) >= 250
+        preview[clipped] = (0, 0, 255)
+        self.target_mapper.draw_cached_detections(preview)
+        h, w = preview.shape[:2]
+        if w > max_width:
+            preview = cv2.resize(preview,
+                                 (max_width, int(h * max_width / w)),
+                                 interpolation=cv2.INTER_AREA)
+        return preview
+
+    def _eye_preview(self, max_width: int = 380) -> Optional[np.ndarray]:
+        """Downscaled annotated eye frame (pupil ellipse + status drawings)
+        for the calibration overlay preview."""
+        frame = self.last_eye_frame_annotated
+        if frame is None:
+            return None
+        h, w = frame.shape[:2]
+        if w <= max_width:
+            return frame
+        return cv2.resize(frame, (max_width, int(h * max_width / w)),
+                          interpolation=cv2.INTER_AREA)
 
     def _predict_gaze_scene_xy(self) -> Optional[tuple]:
         """Return (x, y) in scene-cam pixels, smoothed and clipped, or None
@@ -274,6 +320,10 @@ class App:
         elif key == 's':
             if self.routine.is_active:
                 self.routine.skip()
+        elif key == 'esc':
+            # Abort the in-progress fixation, stay on the same point
+            # (no-op unless collecting).
+            self.routine.abort_capture()
         elif key == 'r':
             self.pupil.reset()
             print("Pupil 3D model reset — give it ~30s to reconverge.")
@@ -285,6 +335,13 @@ class App:
             self._nudge_exposure(-1, EXPOSURE_STEP_COARSE)
         elif key == '}':
             self._nudge_exposure(+1, EXPOSURE_STEP_COARSE)
+        elif key == '-':
+            self.overlay.nudge_marker_white(-1)
+        elif key == '=':
+            self.overlay.nudge_marker_white(+1)
+        elif key == 'p':
+            if self.routine.is_active:
+                self.overlay.toggle_preview()
         return True
 
     # ---- exposure controls (scene cam only) ---------------------------------

--- a/scripts/eyetracker/app.py
+++ b/scripts/eyetracker/app.py
@@ -49,6 +49,8 @@ class App:
                  target_mapper: ArucoHomography,
                  quick_routine: CalibrationRoutine,
                  detailed_routine: CalibrationRoutine,
+                 multipose_routine: CalibrationRoutine,
+                 validation_routine: CalibrationRoutine,
                  overlay: CalibrationOverlay,
                  display: Display):
         self.eye_cam = eye_cam
@@ -61,10 +63,15 @@ class App:
         self.target_mapper = target_mapper
         self.quick_routine = quick_routine
         self.detailed_routine = detailed_routine
+        self.multipose_routine = multipose_routine
+        self.validation_routine = validation_routine
         # `routine` is the currently-active calibration state machine.
-        # `_start_calibration` reassigns it to quick_routine or
-        # detailed_routine depending on which hotkey the user pressed.
+        # `_start_calibration` reassigns it to whichever routine the hotkey
+        # selected (quick / detailed / multi-pose / validation).
         self.routine = quick_routine
+        # All routines that need scene_size + jump_gate wired before use.
+        self._all_routines = (quick_routine, detailed_routine,
+                              multipose_routine, validation_routine)
         self.overlay = overlay
         self.display = display
 
@@ -86,14 +93,15 @@ class App:
         if self.scene_cam is not None:
             print(f"Scene cam: {self.scene_cam.width}x{self.scene_cam.height}")
             scene_size = (self.scene_cam.width, self.scene_cam.height)
-            self.quick_routine.scene_size = scene_size
-            self.detailed_routine.scene_size = scene_size
+            for routine in self._all_routines:
+                routine.scene_size = scene_size
 
-        self.quick_routine.jump_gate = self.jump_gate
-        self.detailed_routine.jump_gate = self.jump_gate
+        for routine in self._all_routines:
+            routine.jump_gate = self.jump_gate
         self.display.open()
 
         print("Controls: 'c' = quick calibrate, 'd' = detailed calibrate, "
+              "'m' = multi-pose calibrate, 'v' = validation capture, "
               "'l' = load calibration, 'r' = reset pupil 3D model, "
               "'q' = quit, space = pause")
         print("Scene exposure: '[' / ']' = darker / brighter (fine), "
@@ -250,11 +258,19 @@ class App:
         elif key == 'c':
             if not self.routine.is_active:
                 self._start_calibration(self.quick_routine)
+            elif self.routine.awaiting_pose:
+                self.routine.begin_next_pose()
             elif not self.routine.is_collecting:
                 self.routine.begin_capture()
         elif key == 'd':
             if not self.routine.is_active:
                 self._start_calibration(self.detailed_routine)
+        elif key == 'm':
+            if not self.routine.is_active:
+                self._start_calibration(self.multipose_routine)
+        elif key == 'v':
+            if not self.routine.is_active:
+                self._start_calibration(self.validation_routine)
         elif key == 's':
             if self.routine.is_active:
                 self.routine.skip()

--- a/scripts/eyetracker/calibration/persistence.py
+++ b/scripts/eyetracker/calibration/persistence.py
@@ -145,12 +145,19 @@ def _scene_intrinsics_snapshot() -> Optional[dict]:
 
 def write_session_metadata(session_dir: str,
                            snapshot: CalibrationSnapshot,
-                           report: FitReport,
-                           degree: int) -> None:
+                           report: Optional[FitReport],
+                           degree: int,
+                           phase: str = "calibration") -> None:
     """Emit `metadata.json` for a finished session: the self-contained dataset
     record. Hardware/subject fields that the pipeline does not yet produce
     (eye intrinsics, extrinsics, subject id, kappa, versions) are written as
-    null placeholders — the extrinsics jig and richer capture fill them later."""
+    null placeholders — the extrinsics jig and richer capture fill them later.
+
+    `phase` distinguishes a normal "calibration" session from a held-out
+    "validation" capture (collected identically but never fitted). A validation
+    session has no fit, so `report` is None and the `fit` field is null; its
+    labels.csv is still the same ground-truth format, so `dataset.py` reads it
+    like any other session — measure_gaze_accuracy uses it as held-out data."""
     sw, sh = snapshot.scene_size if snapshot.scene_size else (None, None)
     pw, ph = snapshot.screen_size if snapshot.screen_size else (None, None)
     eye_w, eye_h = EYE_CAM_RESOLUTION
@@ -159,7 +166,7 @@ def write_session_metadata(session_dir: str,
         "session_id": os.path.basename(os.path.normpath(session_dir)),
         "created_at": datetime.datetime.now().astimezone().isoformat(),
         "timestamp": time.time(),
-        "phase": "calibration",
+        "phase": phase,
         "subject_id": None,
         "glasses": None,
         "headset_model_version": None,
@@ -180,7 +187,7 @@ def write_session_metadata(session_dir: str,
         "rig_calibration_id": None,
         "intrinsics": {"eye": None, "scene": _scene_intrinsics_snapshot()},
         "extrinsics": None,
-        "fit": {
+        "fit": None if report is None else {
             "degree": int(degree),
             "n_points": int(report.n_points),
             "loo_avg_px": float(report.loo_avg_err),

--- a/scripts/eyetracker/calibration/routine.py
+++ b/scripts/eyetracker/calibration/routine.py
@@ -11,6 +11,14 @@ Owns:
 Does NOT own the Tk overlay — the overlay reads routine state and the App
 loop drives it. The routine signals completion by setting `is_active` to
 False; the App is responsible for calling overlay.close() in response.
+
+Two construction-time modes layer on top of the basic grid:
+- `num_poses > 1` (multi-pose): run the same grid at several head poses in
+  one session, pausing in a "pose break" between them, and aggregate every
+  captured point into a single fit. See docs/multipose_calibration.md.
+- `fit_on_finish=False` (validation): capture identically but fit nothing and
+  dump the medians to validation_*.npz instead, leaving the live calibration
+  untouched. See docs/calibration_coverage.md.
 """
 import math
 import os
@@ -33,7 +41,7 @@ from scripts.eyetracker.calibration.persistence import (
     write_session_metadata,
 )
 from scripts.eyetracker.calibration.targets import TargetPattern
-from scripts.eyetracker.config import ARUCO_IDS
+from scripts.eyetracker.config import ARUCO_IDS, CALIB_POSE_GUIDANCE
 from scripts.eyetracker.gaze.base import FitReport, GazeMapper
 from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
 from scripts.eyetracker.pupil.gating import JumpGate
@@ -52,6 +60,8 @@ class CalibrationRoutine:
                  jump_gate: Optional[JumpGate] = None,
                  mapper_degree: int = 2,
                  recapture_worst_n: int = 0,
+                 num_poses: int = 1,
+                 fit_on_finish: bool = True,
                  label: str = "calibration"):
         self.pattern = pattern
         self.collector = collector
@@ -65,6 +75,16 @@ class CalibrationRoutine:
         # 0 = single pass. >0 = after pass-1 fit, drop the N highest-LOO-
         # residual fixations and re-prompt those targets before refitting.
         self.recapture_worst_n = recapture_worst_n
+        # >1 runs the same grid at several head poses in one session and
+        # aggregates all captured points into a single fit, extending pupil/
+        # scene coverage toward the full oculomotor range. Each pose is still
+        # captured static (the per-fixation gate rejects head motion); the user
+        # repositions only between poses.
+        self.num_poses = num_poses
+        # False = collect-only "validation" run: skip fitting / saving the live
+        # calibration and instead dump the captured medians to validation_*.npz
+        # for held-out accuracy measurement.
+        self.fit_on_finish = fit_on_finish
         # Used in console output to distinguish quick vs detailed sessions.
         self.label = label
 
@@ -83,6 +103,11 @@ class CalibrationRoutine:
         self.captured_target_indices: List[int] = []
         # True iff we're currently re-prompting pass-2 (recapture) targets.
         self._in_pass_two: bool = False
+        # Multi-pose state. current_pose is 1-based; _awaiting_pose is the
+        # "grid done, waiting for the user to reposition + press 'c'" break
+        # between poses.
+        self.current_pose: int = 1
+        self._awaiting_pose: bool = False
         # Original (pass-1) targets list, preserved so the saved snapshot
         # records the full screen-point set even after self.targets is
         # narrowed to the recapture subset in pass 2.
@@ -113,6 +138,21 @@ class CalibrationRoutine:
     def collecting_sample_count(self) -> int:
         return self.collector.sample_count()
 
+    @property
+    def awaiting_pose(self) -> bool:
+        """True while paused between poses, waiting for the user to reposition
+        their head and press 'c'. Read by the overlay to show guidance."""
+        return self._awaiting_pose
+
+    def next_pose_guidance(self, pose: Optional[int] = None) -> str:
+        """Human-readable instruction for the given 1-based pose (defaults to
+        the pose we're about to start). Falls back gracefully if there are more
+        poses than guidance strings."""
+        idx = (pose if pose is not None else self.current_pose + 1) - 1
+        if 0 <= idx < len(CALIB_POSE_GUIDANCE):
+            return CALIB_POSE_GUIDANCE[idx]
+        return "reposition your head to a new orientation"
+
     # ---- Lifecycle -----------------------------------------------------------
 
     def start(self, screen_width: int, screen_height: int) -> None:
@@ -128,6 +168,8 @@ class CalibrationRoutine:
         self.captured_target_indices = []
         self._in_pass_two = False
         self._original_targets = []
+        self.current_pose = 1
+        self._awaiting_pose = False
         self.screen_width = screen_width
         self.screen_height = screen_height
         self._pending_rows = []
@@ -144,15 +186,40 @@ class CalibrationRoutine:
         if self.recapture_worst_n > 0:
             print(f"  Two-pass mode: worst {self.recapture_worst_n} fixations "
                   "will be re-prompted after pass 1.")
+        if self.num_poses > 1:
+            print(f"  Multi-pose mode: {self.num_poses} head poses, "
+                  f"{self.total_points} points each (do not remove the headset).")
+            print(f"  Pose 1/{self.num_poses}: {self.next_pose_guidance(1)}")
+        if not self.fit_on_finish:
+            print("  Validation mode: collect-only, the live calibration "
+                  "is left untouched.")
         print(f"  Dataset: {self.session_dir}")
         print("  Look at the RED dot and press 'c'.")
 
     def begin_capture(self) -> None:
         """User pressed 'c' on an idle target. Start the per-fixation buffer."""
-        if not self.is_active or self.is_collecting:
+        if not self.is_active or self.is_collecting or self._awaiting_pose:
             return
         self.is_collecting = True
         self.collector.begin()
+
+    def begin_next_pose(self) -> None:
+        """User pressed 'c' during a pose break. Re-arm the same grid for the
+        next pose, keeping the points captured so far so they all feed one fit."""
+        if not (self.is_active and self._awaiting_pose):
+            return
+        self.current_pose += 1
+        self._awaiting_pose = False
+        self.current_idx = 0
+        self.targets = self.pattern.generate(self.screen_width, self.screen_height)
+        self.skipped_indices = []
+        self.is_collecting = False
+        self.collector.reset()
+        if self.jump_gate is not None:
+            self.jump_gate.reset()
+        print(f"Pose {self.current_pose}/{self.num_poses}: "
+              f"{self.next_pose_guidance(self.current_pose)}")
+        print("  Look at the RED dot and press 'c'.")
 
     def skip(self) -> None:
         """User pressed 's'. Mark current target skipped, advance or finish."""
@@ -281,7 +348,10 @@ class CalibrationRoutine:
 
     def _advance_or_finish(self) -> None:
         if self.current_idx + 1 >= self.total_points:
-            self._finish()
+            if self.current_pose < self.num_poses and not self._in_pass_two:
+                self._begin_pose_break()
+            else:
+                self._finish()
         else:
             self.current_idx += 1
             captured = len(self.captured_pupil)
@@ -292,9 +362,27 @@ class CalibrationRoutine:
                     print(f"  Captured {captured}/{self.total_points}. "
                           "Look at next dot, press 'c'.")
 
+    def _begin_pose_break(self) -> None:
+        """Grid for the current pose is done but more poses remain — pause and
+        wait for the user to reposition. Buffers are intentionally NOT cleared
+        so points accumulate across poses into one fit."""
+        self._awaiting_pose = True
+        self.is_collecting = False
+        self.collector.reset()
+        captured = len(self.captured_pupil)
+        next_pose = self.current_pose + 1
+        print(f"Pose {self.current_pose}/{self.num_poses} done "
+              f"({captured} points so far).")
+        print(f"  Next, {self.next_pose_guidance(next_pose)}, then press 'c' "
+              f"to start pose {next_pose}/{self.num_poses}.")
+
     def _finish(self) -> None:
         n = len(self.captured_pupil)
         skipped = len(self.skipped_indices)
+        if not self.fit_on_finish:
+            self._save_validation(n)
+            self._end()
+            return
         if isinstance(self.mapper, PolynomialGazeMapper):
             self.mapper.set_degree(self.mapper_degree)
         min_pts = self._min_fit_points()
@@ -319,6 +407,23 @@ class CalibrationRoutine:
 
         self._report_and_save(report)
         self._end()
+
+    def _save_validation(self, n: int) -> None:
+        """Finish a collect-only validation run. The samples are already in the
+        session's labels.csv (written during capture, same as any calibration);
+        we only stamp a metadata.json tagged phase="validation" with no fit, so
+        dataset.py reads it like a normal session and measure_gaze_accuracy can
+        use it as held-out data. The live calibration.json is never touched."""
+        if n < 1:
+            print("No points captured — nothing to save as validation.")
+            return
+        if self.session_dir is None:
+            return
+        snapshot = self._build_snapshot()
+        write_session_metadata(self.session_dir, snapshot, report=None,
+                               degree=self.mapper_degree, phase="validation")
+        print(f"Validation capture complete ({n} points, held out — "
+              "the live calibration is unchanged).")
 
     def _min_fit_points(self) -> int:
         if isinstance(self.mapper, PolynomialGazeMapper):
@@ -407,11 +512,16 @@ class CalibrationRoutine:
         screen_size = ((self.screen_width, self.screen_height)
                        if self.screen_width is not None and self.screen_height is not None
                        else None)
-        # In pass 2, self.targets has been narrowed to the recapture subset
-        # — record the full pass-1 set in the saved snapshot.
-        screen_targets = (self._original_targets
-                          if self._in_pass_two and self._original_targets
-                          else self.targets)
+        # In pass 2 the captured_target_indices mapping is no longer valid
+        # (self.targets was narrowed to the recapture subset), so fall back to
+        # the preserved full pass-1 grid. Otherwise map each captured fixation
+        # back to its on-screen target so screen_points stays length-matched to
+        # pupil_vectors — across skips and across repeated grids in multi-pose.
+        if self._in_pass_two and self._original_targets:
+            screen_targets = self._original_targets
+        else:
+            screen_targets = [self.targets[idx]
+                              for idx in self.captured_target_indices]
         return CalibrationSnapshot(
             pupil_vectors=np.array(self.captured_pupil),
             scene_points=np.array(self.captured_scene),

--- a/scripts/eyetracker/calibration/routine.py
+++ b/scripts/eyetracker/calibration/routine.py
@@ -41,7 +41,11 @@ from scripts.eyetracker.calibration.persistence import (
     write_session_metadata,
 )
 from scripts.eyetracker.calibration.targets import TargetPattern
-from scripts.eyetracker.config import ARUCO_IDS, CALIB_POSE_GUIDANCE
+from scripts.eyetracker.config import (
+    ARUCO_IDS,
+    CALIB_POSE_GUIDANCE,
+    CALIB_SAMPLE_TIMEOUT_S,
+)
 from scripts.eyetracker.gaze.base import FitReport, GazeMapper
 from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
 from scripts.eyetracker.pupil.gating import JumpGate
@@ -120,6 +124,15 @@ class CalibrationRoutine:
         self.session_dir: Optional[str] = None
         self.labels_path: Optional[str] = None
 
+        # Transient status line rendered by the overlay (collector-reject
+        # reason, stall timeout, manual abort). Cleared when a new capture or
+        # pose starts. Console prints alone are invisible behind the
+        # fullscreen overlay — this is the on-screen copy.
+        self.notice: str = ""
+        # Timestamp of the last sample landed while collecting; drives the
+        # stall timeout. Refreshed by warmup frames so warmup doesn't count.
+        self._last_sample_ts: float = 0.0
+
         # Pending state cleared on every reject / advance / skip.
         self._pending_rows: list = []
         self._pending_image_paths: List[str] = []
@@ -170,6 +183,7 @@ class CalibrationRoutine:
         self._original_targets = []
         self.current_pose = 1
         self._awaiting_pose = False
+        self.notice = ""
         self.screen_width = screen_width
         self.screen_height = screen_height
         self._pending_rows = []
@@ -201,6 +215,8 @@ class CalibrationRoutine:
         if not self.is_active or self.is_collecting or self._awaiting_pose:
             return
         self.is_collecting = True
+        self.notice = ""
+        self._last_sample_ts = time.time()
         self.collector.begin()
 
     def begin_next_pose(self) -> None:
@@ -210,6 +226,7 @@ class CalibrationRoutine:
             return
         self.current_pose += 1
         self._awaiting_pose = False
+        self.notice = ""
         self.current_idx = 0
         self.targets = self.pattern.generate(self.screen_width, self.screen_height)
         self.skipped_indices = []
@@ -233,9 +250,22 @@ class CalibrationRoutine:
             self.is_collecting = False
             self.collector.reset()
 
+        self.notice = ""
         self.skipped_indices.append(self.current_idx)
         print(f"Skipped point {self.current_idx + 1}/{self.total_points}.")
         self._advance_or_finish()
+
+    def abort_capture(self, reason: str = "Aborted — press 'c' to retry.") -> None:
+        """Abandon the in-progress fixation (Esc key, or the stall timeout):
+        throw away pending rows/images and return to the idle "press 'c'"
+        state on the SAME point. skip() by contrast advances past the point."""
+        if not (self.is_active and self.is_collecting):
+            return
+        self._discard_pending()
+        self.is_collecting = False
+        self.collector.reset()
+        self.notice = reason
+        print(f"  {reason}")
 
     # ---- Per-frame drive -----------------------------------------------------
 
@@ -249,9 +279,20 @@ class CalibrationRoutine:
         the pupil pipeline; pass them straight in."""
         if not (self.is_active and self.is_collecting):
             return
+        # Stall check first — the early-returns below (no pupil, no scene,
+        # no homography) are exactly the conditions that used to leave a
+        # point "collecting" forever while the user drifted off-target.
+        now = time.time()
+        if now - self._last_sample_ts > CALIB_SAMPLE_TIMEOUT_S:
+            self.abort_capture(
+                f"Timed out ({CALIB_SAMPLE_TIMEOUT_S:.0f}s without a usable "
+                "sample) — adjust and press 'c' to retry.")
+            return
         if pupil_center is None or eye_frame is None:
             return
         if self.collector.consume_warmup_frame():
+            # Warmup frames don't count toward the stall clock.
+            self._last_sample_ts = now
             return
 
         if scene_frame is None:
@@ -259,7 +300,10 @@ class CalibrationRoutine:
                             "  No scene camera — cannot calibrate in scene-cam mode.")
             return
 
-        H, _ = self.target_mapper.compute_homography(scene_frame)
+        # The App already ran process_frame() (one ArUco detection) on this
+        # exact frame before handing it to us — solve from that cache instead
+        # of paying a second detection pass per frame.
+        H, _ = self.target_mapper.cached_homography()
         if H is None:
             self._throttled("_last_aruco_log_ts",
                             "  [aruco] not all 4 markers visible")
@@ -294,28 +338,26 @@ class CalibrationRoutine:
 
         result = self.collector.add(np.array(pupil_center, dtype=float),
                                     np.array([target_u, target_v], dtype=float))
+        self._last_sample_ts = now
         if result is None:
             return
         if isinstance(result, CollectorReject):
             print(f"  {result.reason}")
+            self.notice = result.reason
             self._discard_pending()
             self.is_collecting = False
             self.collector.reset()
             return
         assert isinstance(result, CollectorAccept)
-        self._accept(result, scene_frame, target_u, target_v)
+        self._accept(result)
 
     # ---- Internals -----------------------------------------------------------
 
-    def _accept(self,
-                result: CollectorAccept,
-                scene_frame: np.ndarray,
-                target_u: float,
-                target_v: float) -> None:
+    def _accept(self, result: CollectorAccept) -> None:
         self.captured_pupil.append(result.pupil_median)
         self.captured_scene.append(result.scene_median)
         self.captured_target_indices.append(self.current_idx)
-        self._log_aruco_check(scene_frame, result.scene_median)
+        self._log_aruco_check(result.scene_median)
         append_label_rows(self.labels_path, self._pending_rows)
         self._pending_rows = []
         self._pending_image_paths = []
@@ -323,10 +365,9 @@ class CalibrationRoutine:
         self.collector.reset()
         self._advance_or_finish()
 
-    def _log_aruco_check(self, scene_frame: np.ndarray,
-                          scene_median: np.ndarray) -> None:
+    def _log_aruco_check(self, scene_median: np.ndarray) -> None:
         try:
-            H_chk, reproj_err = self.target_mapper.compute_homography(scene_frame)
+            H_chk, reproj_err = self.target_mapper.cached_homography()
         except Exception as e:
             print(f"  ArUco detection error for fixation {self.current_idx}: {e}")
             return

--- a/scripts/eyetracker/config.py
+++ b/scripts/eyetracker/config.py
@@ -85,6 +85,11 @@ CALIB_INLIERS = 10
 CALIB_STD_THRESH = 12.0
 CALIB_SCENE_STD_THRESH = 10.0
 CALIB_WARMUP = 5
+# Abort a stuck fixation: while collecting, if no sample has landed for this
+# long (pupil lost, markers dropped, glare), stop collecting and return to the
+# idle "press 'c'" state on the same point instead of hanging until the user
+# drifts and pollutes the capture. Warmup frames don't count toward the clock.
+CALIB_SAMPLE_TIMEOUT_S = 5.0
 
 # Quick cal: 3x3 grid (9 pts = 4 corners + 4 edge midpoints + center) with a
 # degree-2 polynomial (6 coeffs, so 1.5x overdetermined — enough to average out
@@ -143,3 +148,12 @@ ARUCO_DICT_NAME = "DICT_4X4_50"
 ARUCO_MARKER_PX = 120
 ARUCO_QUIET_ZONE_PX = 140
 ARUCO_IDS = (0, 1, 2, 3)
+# Displayed brightness (0-255) of the marker white cells AND quiet zones —
+# they must match or detection contrast suffers. Full white can bloom/clip on
+# the scene cam; dropping toward grey keeps the cells in the sensor's linear
+# range. ArUco thresholds adaptively so grey-on-black still detects; keep
+# comfortably above the black cells. Adjustable live with '-' / '=' during
+# calibration (steps of ARUCO_WHITE_STEP, floor at ARUCO_WHITE_MIN).
+ARUCO_WHITE_LEVEL = 255
+ARUCO_WHITE_STEP = 15
+ARUCO_WHITE_MIN = 60

--- a/scripts/eyetracker/config.py
+++ b/scripts/eyetracker/config.py
@@ -105,6 +105,37 @@ CALIB_DETAILED_MARGIN = 180
 CALIB_DETAILED_DEGREE = 3
 CALIB_DETAILED_RECAPTURE_WORST = 5
 
+# Multi-pose cal ('m'): run a grid at several head orientations in ONE session
+# (without removing the headset) so the eye sweeps a wider range than a head-on
+# screen allows, extending pupil/scene coverage toward the full oculomotor
+# range. Each pose is captured static; the user repositions only between poses.
+# CALIB_POSES grids x CALIB_MULTIPOSE_(ROWS*COLS) points feed a single fit, so
+# keep the grid modest. Recapture is disabled in multi-pose (pose-ambiguous).
+# 3 = head-on + left + right (horizontal coverage), which is most of the gain
+# for a much shorter session. Bump toward 5 to add the down/up poses (vertical
+# coverage) at the cost of more user effort; CALIB_POSE_GUIDANCE supports up to
+# 5 before falling back to a generic prompt.
+CALIB_POSES = 3
+CALIB_MULTIPOSE_ROWS = 3
+CALIB_MULTIPOSE_COLS = 4
+CALIB_MULTIPOSE_MARGIN = 180
+CALIB_MULTIPOSE_DEGREE = 3
+# Guidance shown per 1-based pose. Poses beyond this list fall back to a
+# generic prompt (see CalibrationRoutine.next_pose_guidance).
+CALIB_POSE_GUIDANCE = (
+    "look head-on — face the screen squarely",
+    "turn your head LEFT, keep looking at the screen",
+    "turn your head RIGHT, keep looking at the screen",
+    "tilt your head DOWN (chin down), keep looking at the screen",
+    "tilt your head UP (chin up), keep looking at the screen",
+)
+
+# Validation capture ('v'): runs the detailed grid but fits nothing and leaves
+# the live calibration untouched — it dumps held-out (pupil, scene-label) pairs
+# to validation_*.npz for measure_gaze_accuracy.py. Run it at a steep head
+# angle to probe accuracy outside the calibrated region.
+CALIB_VALIDATION_DEGREE = 3
+
 
 # ---- ArUco corner markers ----------------------------------------------------
 # IDs: 0=TL, 1=TR, 2=BR, 3=BL.

--- a/scripts/eyetracker/display/base.py
+++ b/scripts/eyetracker/display/base.py
@@ -43,6 +43,19 @@ class Display(ABC):
 
 
 class CalibrationOverlay(ABC):
+    # Per-frame state stamped by the App before render(); implementations may
+    # ignore them. exposure_status is a one-line scene-exposure summary;
+    # pupil_ok is whether the pupil pipeline produced an accepted center this
+    # frame (post confidence + jump gates).
+    exposure_status: str = ""
+    pupil_ok: bool = True
+    # In-overlay camera preview ('p' hotkey). preview_enabled is owned by the
+    # overlay (toggle_preview); while it is True the App stamps the two frames
+    # (BGR arrays, already annotated + downscaled) before each render().
+    preview_enabled: bool = False
+    preview_scene: Optional[np.ndarray] = None
+    preview_eye: Optional[np.ndarray] = None
+
     @abstractmethod
     def open(self) -> Tuple[int, int]:
         """Open the fullscreen overlay; return (screen_width, screen_height)."""
@@ -64,3 +77,10 @@ class CalibrationOverlay(ABC):
     @abstractmethod
     def poll_key(self) -> Optional[str]:
         """Return the next queued key char, or None."""
+
+    def nudge_marker_white(self, direction: int) -> None:
+        """Optional: adjust the displayed ArUco white level by one step
+        (+1 brighter / -1 darker). Default: no-op."""
+
+    def toggle_preview(self) -> None:
+        """Optional: toggle the in-overlay camera preview. Default: no-op."""

--- a/scripts/eyetracker/display/tk_overlay.py
+++ b/scripts/eyetracker/display/tk_overlay.py
@@ -9,14 +9,24 @@ import base64
 import tkinter as tk
 from typing import List, Optional, Tuple
 
+import numpy as np
+
 from scripts.eyetracker.config import (
     ARUCO_MARKER_PX,
     ARUCO_QUIET_ZONE_PX,
+    ARUCO_WHITE_LEVEL,
+    ARUCO_WHITE_MIN,
+    ARUCO_WHITE_STEP,
     CALIB_SAMPLES,
 )
 from scripts.eyetracker.display.base import CalibrationOverlay
 from scripts.eyetracker.scene.aruco_dict import generate_marker_png
 from scripts.eyetracker.scene.aruco_homography import ArucoHomography
+
+
+# Human-readable corner names, index-matched to config.ARUCO_IDS (0=TL, 1=TR,
+# 2=BR, 3=BL) — used to say WHICH marker is missing in the bottom HUD.
+_CORNER_NAMES = ("TL", "TR", "BR", "BL")
 
 
 class TkCalibrationOverlay(CalibrationOverlay):
@@ -28,6 +38,21 @@ class TkCalibrationOverlay(CalibrationOverlay):
         self._photo_images: list = []
         self.screen_width = 0
         self.screen_height = 0
+        # Per-frame state stamped by the App before render() (the App owns
+        # the camera + pupil pipeline; the overlay just draws).
+        self.exposure_status = ""
+        self.pupil_ok = True
+        # Displayed white level of markers + quiet zones; '-'/'=' nudge it
+        # when full white blooms on the scene cam. Session-only (resets to
+        # the config default on restart).
+        self.marker_white_level = ARUCO_WHITE_LEVEL
+        # Camera preview ('p'): frames stamped by the App while enabled.
+        # _preview_photos holds this frame's PhotoImages — Tk only keeps a
+        # weak handle, so dropping the Python reference blanks the canvas.
+        self.preview_enabled = False
+        self.preview_scene: Optional[np.ndarray] = None
+        self.preview_eye: Optional[np.ndarray] = None
+        self._preview_photos: list = []
 
     # ---- lifecycle ----
 
@@ -48,9 +73,17 @@ class TkCalibrationOverlay(CalibrationOverlay):
                            bg="black", highlightthickness=0)
         canvas.pack(fill="both", expand=True)
 
-        for ch in ("c", "s", "q"):
-            root.bind(f"<KeyPress-{ch}>",
+        # The fullscreen overlay owns keyboard focus during calibration, so
+        # every key the App should react to must be bound here or it is
+        # silently swallowed. Brackets/braces are the scene-exposure nudges
+        # (App._handle_key); Escape aborts the in-progress fixation.
+        for keysym, ch in (("c", "c"), ("s", "s"), ("q", "q"),
+                           ("bracketleft", "["), ("bracketright", "]"),
+                           ("braceleft", "{"), ("braceright", "}"),
+                           ("minus", "-"), ("equal", "="), ("p", "p")):
+            root.bind(f"<KeyPress-{keysym}>",
                       lambda _e, _ch=ch: self._on_key(_ch))
+        root.bind("<KeyPress-Escape>", lambda _e: self._on_key("esc"))
         root.focus_force()
         root.update()
 
@@ -70,6 +103,10 @@ class TkCalibrationOverlay(CalibrationOverlay):
         self._root = None
         self._canvas = None
         self._photo_images = []
+        self._preview_photos = []
+        self.preview_enabled = False
+        self.preview_scene = None
+        self.preview_eye = None
 
     def pump(self) -> None:
         if self._root is None:
@@ -108,10 +145,7 @@ class TkCalibrationOverlay(CalibrationOverlay):
                 r = 20
                 canvas.create_oval(x - r, y - r, x + r, y + r,
                                    fill="red", outline="")
-                if routine.is_collecting:
-                    rr = 30
-                    canvas.create_oval(x - rr, y - rr, x + rr, y + rr,
-                                       outline="#ffa500", width=3)
+                self._draw_active_indicators(x, y, routine)
             elif i < active_idx:
                 r = 8
                 canvas.create_oval(x - r, y - r, x + r, y + r,
@@ -129,17 +163,19 @@ class TkCalibrationOverlay(CalibrationOverlay):
                       + status)
         if routine.is_collecting:
             status += (f" - collecting "
-                       f"[{routine.collecting_sample_count}/{CALIB_SAMPLES}]")
+                       f"[{routine.collecting_sample_count}/{CALIB_SAMPLES}] "
+                       "(Esc = abort)")
         else:
-            status += " - press 'c' to capture, 's' to skip, 'q' to quit"
+            status += (" - press 'c' to capture, 's' to skip, "
+                       "'p' = preview, 'q' to quit")
         canvas.create_text(self.screen_width // 2, 40, text=status,
                            fill="white", anchor="n", font=("Courier", 20))
+        if routine.notice:
+            canvas.create_text(self.screen_width // 2, 80, text=routine.notice,
+                               fill="#ffb000", anchor="n", font=("Courier", 16))
 
-        marker_count = self.target_mapper.last_marker_count
-        color = "#00ff00" if marker_count == 4 else "#ff6060"
-        canvas.create_text(self.screen_width // 2, self.screen_height - 40,
-                           text=f"aruco: {marker_count}/4 markers visible",
-                           fill=color, anchor="s", font=("Courier", 16))
+        self._draw_bottom_hud()
+        self._draw_preview()
 
     def _render_pose_break(self, routine) -> None:
         """Between-pose screen: keep the ArUco corners up (so the user can
@@ -163,17 +199,157 @@ class TkCalibrationOverlay(CalibrationOverlay):
             text="Reposition, then press 'c' to continue ('q' to quit)",
             fill="white", anchor="n", font=("Courier", 18))
 
+        self._draw_bottom_hud()
+        self._draw_preview()
+
+    def _draw_preview(self) -> None:
+        """Center-screen camera previews ('p' hotkey): the App stamps
+        annotated, pre-downscaled BGR frames; this just PPM-encodes and
+        draws them side by side. Deliberately covers the middle of the
+        screen — it's a between-attempts troubleshooting view, not something
+        to leave up while capturing."""
+        if not self.preview_enabled:
+            return
+        panels = [(label, frame) for label, frame in
+                  (("scene (red = clipped)", self.preview_scene),
+                   ("eye", self.preview_eye))
+                  if frame is not None]
+        if not panels:
+            return
+        canvas = self._canvas
+        self._preview_photos = []
+        gap = 24
+        pad = 10
+        total_w = (sum(frame.shape[1] for _, frame in panels)
+                   + gap * (len(panels) - 1))
+        x = (self.screen_width - total_w) // 2
+        center_y = self.screen_height // 2
+        for label, frame in panels:
+            h, w = frame.shape[:2]
+            top = center_y - h // 2
+            photo = self._photo_from_bgr(frame)
+            self._preview_photos.append(photo)
+            canvas.create_rectangle(x - pad, top - pad - 20,
+                                    x + w + pad, top + h + pad,
+                                    fill="#181818", outline="#606060")
+            canvas.create_text(x, top - 4, text=label,
+                               fill="#c0c0c0", anchor="sw",
+                               font=("Courier", 13))
+            canvas.create_image(x, top, anchor="nw", image=photo)
+            x += w + gap
+
+    def _photo_from_bgr(self, frame_bgr: np.ndarray) -> tk.PhotoImage:
+        """BGR array -> tk.PhotoImage via raw PPM bytes (P6) — no PNG
+        compression, cheap enough to do per frame."""
+        rgb = np.ascontiguousarray(frame_bgr[:, :, ::-1])
+        h, w = rgb.shape[:2]
+        header = f"P6 {w} {h} 255 ".encode()
+        return tk.PhotoImage(master=self._root, data=header + rgb.tobytes(),
+                             format="PPM")
+
+    def _draw_active_indicators(self, x: int, y: int, routine) -> None:
+        """Peripheral status around the active dot — quiet when healthy, loud
+        when something is wrong — so the user can hold fixation and still see
+        why capture isn't progressing (peripheral vision resolves the
+        appearance of a thick ring far better than a color change).
+
+        - collecting: dark track ring + orange progress arc (samples/target),
+          clockwise from 12 o'clock
+        - pupil not detected this frame: solid red inner ring
+        - ArUco marker missing: red arc on the outer ring, in the screen
+          quadrant of that marker (TL/TR/BR/BL) — points at the problem corner
+        """
+        canvas = self._canvas
+        if routine.is_collecting:
+            track_r = 28
+            canvas.create_oval(x - track_r, y - track_r,
+                               x + track_r, y + track_r,
+                               outline="#404040", width=4)
+            frac = min(routine.collecting_sample_count / CALIB_SAMPLES, 1.0)
+            if frac > 0:
+                # Negative extent sweeps clockwise; 359.9 because Tk treats
+                # a full ±360 arc as extent 0 and draws nothing.
+                canvas.create_arc(x - track_r, y - track_r,
+                                  x + track_r, y + track_r,
+                                  start=90, extent=-359.9 * frac,
+                                  style=tk.ARC, outline="#ffa500", width=4)
+
+        if not self.pupil_ok:
+            pupil_r = 38
+            canvas.create_oval(x - pupil_r, y - pupil_r,
+                               x + pupil_r, y + pupil_r,
+                               outline="#ff2020", width=5)
+
+        from scripts.eyetracker.config import ARUCO_IDS
+        found = self.target_mapper.last_found_ids
+        marker_r = 48
+        # Tk arc angles: 0 = 3 o'clock, counterclockwise. Quadrant start
+        # angles index-matched to ARUCO_IDS order (TL, TR, BR, BL).
+        quadrant_starts = (90, 0, 270, 180)
+        for marker_id, start in zip(ARUCO_IDS, quadrant_starts):
+            if marker_id not in found:
+                canvas.create_arc(x - marker_r, y - marker_r,
+                                  x + marker_r, y + marker_r,
+                                  start=start, extent=90,
+                                  style=tk.ARC, outline="#ff2020", width=5)
+
+    def _draw_bottom_hud(self) -> None:
+        """Bottom-of-screen diagnostics, stacked upward from the bottom:
+        marker visibility (naming any missing corner), a pupil-lost warning,
+        and the scene-exposure state with its nudge keys."""
+        canvas = self._canvas
+        center_x = self.screen_width // 2
         marker_count = self.target_mapper.last_marker_count
+        text = f"aruco: {marker_count}/4 markers visible"
+        if marker_count < 4:
+            from scripts.eyetracker.config import ARUCO_IDS
+            found = self.target_mapper.last_found_ids
+            missing = [name for marker_id, name in zip(ARUCO_IDS, _CORNER_NAMES)
+                       if marker_id not in found]
+            text += f" - missing: {', '.join(missing)}"
         color = "#00ff00" if marker_count == 4 else "#ff6060"
+        canvas.create_text(center_x, self.screen_height - 40,
+                           text=text,
+                           fill=color, anchor="s", font=("Courier", 16))
+        if not self.pupil_ok:
+            canvas.create_text(center_x, self.screen_height - 66,
+                               text="pupil: not detected",
+                               fill="#ff6060", anchor="s", font=("Courier", 16))
+        if self.exposure_status:
+            canvas.create_text(
+                center_x, self.screen_height - 92,
+                text=f"{self.exposure_status}  ('['/']' fine, '{{'/'}}' coarse)",
+                fill="#b0b0b0", anchor="s", font=("Courier", 14))
         canvas.create_text(
-            cx, self.screen_height - 40,
-            text=f"aruco: {marker_count}/4 markers visible",
-            fill=color, anchor="s", font=("Courier", 16))
+            center_x, self.screen_height - 116,
+            text=(f"marker white: {self.marker_white_level}/255  "
+                  "('-'/'=' adjust)"),
+            fill="#b0b0b0", anchor="s", font=("Courier", 14))
 
     # ---- internals ----
 
     def _on_key(self, ch: str) -> None:
         self._key_queue.append(ch)
+
+    def toggle_preview(self) -> None:
+        """Show/hide the center-screen camera previews ('p' hotkey)."""
+        self.preview_enabled = not self.preview_enabled
+        if not self.preview_enabled:
+            self.preview_scene = None
+            self.preview_eye = None
+            self._preview_photos = []
+
+    def nudge_marker_white(self, direction: int) -> None:
+        """Adjust the displayed white level of the markers + quiet zones by
+        one ARUCO_WHITE_STEP ('-'/'=' hotkeys). Invalidates the marker
+        PhotoImage cache so the next draw rebuilds at the new level."""
+        new_level = self.marker_white_level + direction * ARUCO_WHITE_STEP
+        new_level = max(ARUCO_WHITE_MIN, min(255, new_level))
+        if new_level == self.marker_white_level:
+            return
+        self.marker_white_level = new_level
+        self._photo_images = []
+        print(f"[markers] white level = {self.marker_white_level}/255")
 
     def _ensure_aruco_photo_images(self):
         if len(self._photo_images) == 4:
@@ -181,7 +357,8 @@ class TkCalibrationOverlay(CalibrationOverlay):
         from scripts.eyetracker.config import ARUCO_IDS
         imgs = []
         for marker_id in ARUCO_IDS:
-            png_bytes = generate_marker_png(marker_id, ARUCO_MARKER_PX)
+            png_bytes = generate_marker_png(marker_id, ARUCO_MARKER_PX,
+                                            self.marker_white_level)
             b64 = base64.b64encode(png_bytes)
             # Bind to this session's root explicitly. Without master=, Tk uses
             # the stale tkinter._default_root (a prior, destroyed root that
@@ -202,9 +379,13 @@ class TkCalibrationOverlay(CalibrationOverlay):
         from scripts.eyetracker.config import ARUCO_IDS
         q = ARUCO_QUIET_ZONE_PX
         inset = (q - ARUCO_MARKER_PX) // 2
+        # Quiet zone must be the SAME grey as the marker's white cells — a
+        # dimmed marker inside a full-white zone kills detection contrast.
+        level = self.marker_white_level
+        quiet_zone_fill = f"#{level:02x}{level:02x}{level:02x}"
         for i, marker_id in enumerate(ARUCO_IDS):
             ox, oy = origins[marker_id]
             canvas.create_rectangle(ox, oy, ox + q, oy + q,
-                                    fill="white", outline="")
+                                    fill=quiet_zone_fill, outline="")
             canvas.create_image(ox + inset, oy + inset, anchor="nw",
                                 image=photos[i])

--- a/scripts/eyetracker/display/tk_overlay.py
+++ b/scripts/eyetracker/display/tk_overlay.py
@@ -89,6 +89,11 @@ class TkCalibrationOverlay(CalibrationOverlay):
         if canvas is None:
             return
         canvas.delete("all")
+
+        if getattr(routine, "awaiting_pose", False):
+            self._render_pose_break(routine)
+            return
+
         active_idx = routine.current_idx
 
         for i, pt in enumerate(routine.targets):
@@ -119,6 +124,9 @@ class TkCalibrationOverlay(CalibrationOverlay):
         self._draw_aruco_corners()
 
         status = f"Point {active_idx + 1}/{routine.total_points}"
+        if getattr(routine, "num_poses", 1) > 1:
+            status = (f"Pose {routine.current_pose}/{routine.num_poses}  "
+                      + status)
         if routine.is_collecting:
             status += (f" - collecting "
                        f"[{routine.collecting_sample_count}/{CALIB_SAMPLES}]")
@@ -133,6 +141,35 @@ class TkCalibrationOverlay(CalibrationOverlay):
                            text=f"aruco: {marker_count}/4 markers visible",
                            fill=color, anchor="s", font=("Courier", 16))
 
+    def _render_pose_break(self, routine) -> None:
+        """Between-pose screen: keep the ArUco corners up (so the user can
+        check marker visibility while repositioning) and show the next-pose
+        instruction."""
+        canvas = self._canvas
+        self._draw_aruco_corners()
+        cx = self.screen_width // 2
+        cy = self.screen_height // 2
+        canvas.create_text(
+            cx, cy - 40,
+            text=f"Pose {routine.current_pose}/{routine.num_poses} done",
+            fill="white", anchor="s", font=("Courier", 28))
+        canvas.create_text(
+            cx, cy,
+            text=f"Next: {routine.next_pose_guidance()}",
+            fill="#ffd000", anchor="center", font=("Courier", 22),
+            width=int(self.screen_width * 0.7))
+        canvas.create_text(
+            cx, cy + 70,
+            text="Reposition, then press 'c' to continue ('q' to quit)",
+            fill="white", anchor="n", font=("Courier", 18))
+
+        marker_count = self.target_mapper.last_marker_count
+        color = "#00ff00" if marker_count == 4 else "#ff6060"
+        canvas.create_text(
+            cx, self.screen_height - 40,
+            text=f"aruco: {marker_count}/4 markers visible",
+            fill=color, anchor="s", font=("Courier", 16))
+
     # ---- internals ----
 
     def _on_key(self, ch: str) -> None:
@@ -146,7 +183,11 @@ class TkCalibrationOverlay(CalibrationOverlay):
         for marker_id in ARUCO_IDS:
             png_bytes = generate_marker_png(marker_id, ARUCO_MARKER_PX)
             b64 = base64.b64encode(png_bytes)
-            imgs.append(tk.PhotoImage(data=b64))
+            # Bind to this session's root explicitly. Without master=, Tk uses
+            # the stale tkinter._default_root (a prior, destroyed root that
+            # close() didn't clear), so on the 2nd calibration the image is
+            # created in a dead interpreter -> "image pyimageN doesn't exist".
+            imgs.append(tk.PhotoImage(master=self._root, data=b64))
         self._photo_images = imgs
         return imgs
 

--- a/scripts/eyetracker/gaze/polynomial.py
+++ b/scripts/eyetracker/gaze/polynomial.py
@@ -79,8 +79,16 @@ class PolynomialGazeMapper(GazeMapper):
         self.coeffs_x = cx
         self.coeffs_y = cy
 
+        # Leave-one-out reprojection error, degree-agnostic: for each point,
+        # refit on the other n-1 rows and measure the held-out residual in
+        # scene-cam pixels. Only trustworthy at n >= k + 1 (at n == k the refit
+        # is underdetermined); the configured grids are all above that.
         errors = np.zeros(n)
-         
+        for i in range(n):
+            A_loo = np.delete(A, i, axis=0)
+            cx_loo, _, _, _ = np.linalg.lstsq(A_loo, np.delete(bx, i), rcond=None)
+            cy_loo, _, _, _ = np.linalg.lstsq(A_loo, np.delete(by, i), rcond=None)
+            errors[i] = math.hypot(A[i] @ cx_loo - bx[i], A[i] @ cy_loo - by[i])
 
         return FitReport(n_points=n,
                          loo_avg_err=float(np.mean(errors)),

--- a/scripts/eyetracker/scene/aruco_dict.py
+++ b/scripts/eyetracker/scene/aruco_dict.py
@@ -69,11 +69,16 @@ def detect_markers(scene_bgr: np.ndarray) -> Tuple[Optional[Tuple], Optional[np.
     return corners, ids
 
 
-def generate_marker_png(marker_id: int, size_px: int) -> bytes:
+def generate_marker_png(marker_id: int, size_px: int,
+                        white_level: int = 255) -> bytes:
     """Render a marker to a PNG byte string. Useful for the Tk overlay
-    (which wraps it in a tk.PhotoImage)."""
+    (which wraps it in a tk.PhotoImage). white_level dims the white cells
+    (255 = full white) so they don't bloom on the scene cam; the caller must
+    render the surrounding quiet zone at the same level."""
     _require_aruco()
     img = cv2.aruco.generateImageMarker(get_aruco_dict(), marker_id, size_px)
+    if white_level < 255:
+        img[img > 127] = white_level
     ok, buf = cv2.imencode(".png", img)
     if not ok:
         raise RuntimeError(f"Failed to encode ArUco marker {marker_id} to PNG.")

--- a/scripts/eyetracker/scene/aruco_homography.py
+++ b/scripts/eyetracker/scene/aruco_homography.py
@@ -7,9 +7,13 @@ frame and solve for the screen->scene homography via cv2.findHomography.
 Stateful pieces:
 - screen size (must be set before screen_anchor_points / quiet_zone_origins
   return non-empty results)
-- last marker count (cached for HUD display by the Tk overlay)
+- per-frame detection cache written by process_frame(): last marker count +
+  found IDs (for the Tk overlay HUD) and the raw corners/ids (so
+  cached_homography() can solve without re-running detection — detection on
+  a 1080p frame is the expensive step and used to run twice per frame during
+  collection)
 """
-from typing import Dict, Optional, Tuple
+from typing import Dict, FrozenSet, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -28,6 +32,10 @@ class ArucoHomography(TargetMapper):
         self.screen_width: Optional[int] = None
         self.screen_height: Optional[int] = None
         self.last_marker_count = 0
+        self.last_found_ids: FrozenSet[int] = frozenset()
+        # Raw detection from the most recent process_frame() call.
+        self._cached_corners: Optional[Tuple] = None
+        self._cached_ids: Optional[np.ndarray] = None
 
     def set_screen_size(self, width: int, height: int) -> None:
         self.screen_width = width
@@ -62,26 +70,55 @@ class ArucoHomography(TargetMapper):
             self.marker_ids[3]: (0, sh - q),
         }
 
-    def update_marker_count(self, scene_bgr: Optional[np.ndarray]) -> int:
-        """Detect markers and cache how many of self.marker_ids were found."""
+    def process_frame(self, scene_bgr: Optional[np.ndarray]) -> int:
+        """Run marker detection ONCE for this scene frame and cache the result.
+
+        Call once per new scene frame (the App loop does). Updates
+        last_marker_count / last_found_ids for the overlay HUD and stores the
+        raw corners/ids so cached_homography() can solve without re-detecting.
+        Returns the marker count."""
         if scene_bgr is None:
-            self.last_marker_count = 0
-            return 0
-        _, ids = detect_markers(scene_bgr)
+            corners, ids = None, None
+        else:
+            corners, ids = detect_markers(scene_bgr)
+        self._cached_corners = corners
+        self._cached_ids = ids
         if ids is None:
-            self.last_marker_count = 0
-            return 0
-        found = {int(i) for i in ids.flatten()} & set(self.marker_ids)
-        self.last_marker_count = len(found)
+            self.last_found_ids = frozenset()
+        else:
+            self.last_found_ids = (frozenset(int(i) for i in ids.flatten())
+                                   & frozenset(self.marker_ids))
+        self.last_marker_count = len(self.last_found_ids)
         return self.last_marker_count
+
+    def draw_cached_detections(self, frame_bgr: np.ndarray) -> None:
+        """Outline the markers found by the last process_frame() call onto
+        frame_bgr in place (pass the same frame the cache came from) — used
+        by the calibration overlay's troubleshooting preview."""
+        if self._cached_ids is None or len(self._cached_ids) == 0:
+            return
+        cv2.aruco.drawDetectedMarkers(frame_bgr, self._cached_corners,
+                                      self._cached_ids)
+
+    def cached_homography(self) -> Tuple[Optional[np.ndarray], Optional[float]]:
+        """Solve the homography from the detection cached by the most recent
+        process_frame() call — no re-detection. Only valid for that same frame;
+        callers holding a different frame must use compute_homography()."""
+        return self._homography_from(self._cached_corners, self._cached_ids)
 
     def compute_homography(self, scene_bgr: Optional[np.ndarray]
                            ) -> Tuple[Optional[np.ndarray], Optional[float]]:
-        """Solve for the 3x3 screen->scene homography H and the mean
-        reprojection error in scene-cam pixels. (None, None) on failure."""
+        """Detect markers in scene_bgr and solve for the 3x3 screen->scene
+        homography H and the mean reprojection error in scene-cam pixels.
+        (None, None) on failure. Prefer cached_homography() when
+        process_frame() already ran on this exact frame."""
         if scene_bgr is None:
             return None, None
         corners, ids = detect_markers(scene_bgr)
+        return self._homography_from(corners, ids)
+
+    def _homography_from(self, corners, ids
+                         ) -> Tuple[Optional[np.ndarray], Optional[float]]:
         if ids is None or len(ids) < 4:
             return None, None
         id_to_center: Dict[int, np.ndarray] = {}

--- a/tests/test_polynomial_loo.py
+++ b/tests/test_polynomial_loo.py
@@ -1,0 +1,81 @@
+"""Regression guard for the polynomial mapper's leave-one-out (LOO) error.
+
+LOO has silently regressed to a `np.zeros(n)` stub twice during degree-2/3
+refactors (see docs/loo_error_notes.md). The fit itself stayed correct, so live
+tracking worked — the breakage only showed up in the quality machinery
+(recapture targeting, the high-error warning, and measure_gaze_accuracy, which
+reports the eccentricity-binned LOO table). These asserts fail loudly if the
+refit loop ever disappears again.
+
+No pytest dependency: this uses plain asserts and runs standalone with
+    python -m tests.test_polynomial_loo
+(from the repo root). The functions are named test_* so pytest can also collect
+them if the project adopts it later.
+"""
+import numpy as np
+
+from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
+
+
+def _noisy_quadratic(rng, n):
+    """n pupil points and a known degree-2 scene surface + Gaussian noise, so a
+    correct LOO must be strictly positive (the noise is not fittable)."""
+    pupil = rng.uniform(-1, 1, (n, 2))
+    scene = np.column_stack([
+        3 + 2 * pupil[:, 0] - pupil[:, 1] + 0.5 * pupil[:, 0] ** 2,
+        1 - pupil[:, 0] + 2 * pupil[:, 1] + 0.3 * pupil[:, 1] ** 2,
+    ]) + rng.normal(0, 0.05, (n, 2))
+    return pupil, scene
+
+
+def test_loo_nonzero_on_noisy_data_degree2():
+    """The core guard: LOO must not be identically zero on noisy data."""
+    rng = np.random.default_rng(0)
+    pupil, scene = _noisy_quadratic(rng, 12)
+    report = PolynomialGazeMapper(degree=2).fit(pupil, scene)
+    assert report.loo_avg_err > 0, "degree-2 LOO avg is zero — LOO is stubbed"
+    assert report.loo_max_err > 0
+    assert np.any(report.per_point_errs > 0)
+    assert report.per_point_errs.shape == (12,)
+
+
+def test_loo_nonzero_on_noisy_data_degree3():
+    """Same guard at degree 3 (10 coefficients, so use more points)."""
+    rng = np.random.default_rng(1)
+    pupil, scene = _noisy_quadratic(rng, 20)
+    report = PolynomialGazeMapper(degree=3).fit(pupil, scene)
+    assert report.loo_avg_err > 0, "degree-3 LOO avg is zero — LOO is stubbed"
+    assert np.any(report.per_point_errs > 0)
+    assert report.per_point_errs.shape == (20,)
+
+
+def test_loo_near_zero_on_clean_polynomial():
+    """Positive control: noise-free data lying exactly on a degree-2 surface is
+    perfectly fit, so every held-out prediction is near-exact and LOO ~ 0.
+    (Guards against a fix that just returns a nonzero constant.)"""
+    rng = np.random.default_rng(2)
+    pupil = rng.uniform(-1, 1, (12, 2))
+    scene = np.column_stack([
+        3 + 2 * pupil[:, 0] - pupil[:, 1] + 0.5 * pupil[:, 0] ** 2,
+        1 - pupil[:, 0] + 2 * pupil[:, 1] + 0.3 * pupil[:, 1] ** 2,
+    ])
+    report = PolynomialGazeMapper(degree=2).fit(pupil, scene)
+    assert report.loo_max_err < 1e-6, (
+        f"clean degree-2 data should fit near-exactly, got LOO max "
+        f"{report.loo_max_err}")
+
+
+def _run() -> None:
+    tests = [
+        test_loo_nonzero_on_noisy_data_degree2,
+        test_loo_nonzero_on_noisy_data_degree3,
+        test_loo_near_zero_on_clean_polynomial,
+    ]
+    for test in tests:
+        test()
+        print(f"PASS  {test.__name__}")
+    print(f"\n{len(tests)} passed.")
+
+
+if __name__ == "__main__":
+    _run()


### PR DESCRIPTION
## Multi-pose calibration + eccentricity-binned accuracy tooling

Widen the calibrated region of the field of view and give us the tooling to
*measure* accuracy across it — plus adapt to main's JSON/session persistence.

### Motivation: the coverage problem
A head-on calibration only samples a narrow band of eye rotations (every dot sits
on a monitor filling a small central patch of the scene camera). The pupil→scene
polynomial is trustworthy inside that central cloud and extrapolates badly outside
it, so gaze degrades when the user looks off-center. This PR both extends the
cloud and quantifies the remaining gap. See `docs/calibration_coverage.md` and
`docs/multipose_calibration.md`.

### What's added
- **Multi-pose calibration (`m`)** — run the same grid at several head poses in
  one session (head-on / left / right by default, up to 5) without removing the
  headset. Because the scene cam is head-mounted, rotating the head pushes both
  the pupil and the scene labels to high eccentricity, so all poses aggregate
  into a single fit that covers a wider oculomotor range. Recapture is disabled
  (pose-ambiguous). Config under `CALIB_MULTIPOSE_*` / `CALIB_POSES`.
- **Validation capture (`v`)** — a collect-only run that fits nothing and never
  touches the live calibration. It writes a normal session tagged
  `phase: "validation"` (same `labels.csv`, `metadata.json` with `fit: null`),
  so `dataset.py` reads it like any other session and it doubles as held-out /
  wide-angle training data for later CNN work.
- **`measure_gaze_accuracy.py`, reworked** — reports error **binned by
  eccentricity** (angular distance from the scene-cam principal point) instead of
  a flat per-point dump, plus a coverage histogram of the fit set. `--val` takes
  one or more validation session dirs and evaluates the fit on data it never saw.

### Adapting to main
This branch was built before main migrated persistence from `.npz` to
`calibration.json` + `session_<ts>/{metadata.json,labels.csv}`. Rebased onto that:
validation now rides main's session machinery instead of a standalone `.npz`
(the old `save_validation`/`validation_path` are gone), and
`write_session_metadata` grew a `phase` arg + optional `report` to serve both
calibration and validation sessions.

### Bundled fix: leave-one-out error was stubbed on main
`PolynomialGazeMapper.fit()` on main returns `errors = np.zeros(n)` — the LOO
refit loop had been dropped during the degree-2/3 refactor (see
`docs/loo_error_notes.md`). The fit stayed correct so tracking worked, but every
in-sample accuracy number was 0.0 — which would make this PR's eccentricity table
vacuous. Restored the O(n) refit loop and added `tests/test_polynomial_loo.py` as
a standalone (no-pytest) guard so it can't silently regress again.

### Verification
Ran in the project env against real sessions:
- All touched modules import; `measure_gaze_accuracy` runs end-to-end on a real
  session and on the `--session X --val Y` held-out path.
- LOO regression test passes; with the fix, in-sample accuracy on a 9-point
  session reads **0.19° at 0–5° eccentricity → 0.78° at 15–20°**, directly
  showing the center-vs-edge degradation this PR is about.
- Not yet exercised on hardware: a live `m` multi-pose run and a `v` capture
  end-to-end (needs the cameras).

### Follow-ups (out of scope)
- `TODO_calibration_ux.md` — overlay UX (sample-stall timeout, ready-state dot
  color, pupil-lost warning). Deferred to a follow-up branch.