### PR TITLE
Fix: close calibration overlay when a session ends via skip

### DIFF
--- a/scripts/eyetracker/app.py
+++ b/scripts/eyetracker/app.py
@@ -115,10 +115,6 @@ class App:
                     scene_frame=self.last_scene_frame,
                     confidence=self.last_confidence,
                 )
-            if was_calibration_active and not self.routine.is_active:
-                self.overlay.close()
-                # Reset the gaze smoother so the new fit starts clean.
-                self.smoother.reset()
 
             if self.scene_cam is not None:
                 ext_frame = self.scene_cam.read()
@@ -140,6 +136,18 @@ class App:
             key = tk_key or cv_key
             if not self._handle_key(key, raw):
                 break
+
+            # A calibration session can end either inside tick() above (the last
+            # point was captured) or inside _handle_key() just above (the user
+            # skipped the last point, which runs _finish()). Check the
+            # active->inactive transition after both so the overlay is always
+            # closed. Missing the skip-to-finish case leaves the Tk window
+            # frozen open — and a later restart then spawns a second Tk root,
+            # which is the "image pyimageN doesn't exist" crash.
+            if was_calibration_active and not self.routine.is_active:
+                self.overlay.close()
+                # Reset the gaze smoother so the new fit starts clean.
+                self.smoother.reset()
 
     # ---- per-stage helpers --------------------------------------------------
 


### PR DESCRIPTION
App._loop checked the calibration active->inactive transition only between tick() and key handling. A session finished by skipping the last point ends inside _handle_key (skip -> _finish -> _end), after that check, so the overlay was never closed and the Tk window froze. A later restart then created a second Tk root, surfacing as "image pyimageN doesn't exist".

Move the transition check to after _handle_key so it catches both the capture-completion and skip-to-finish paths.