### PR TITLE
Migrate calibration/session persistence from .npz to JSON + CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ scripts/eyetracker/         # Main Python package — `py -m scripts.eyetracker`
     scene/                  # ArUco detection and screen→scene homography
     gaze/                   # Polynomial mapper, 1€ smoother
     calibration/            # State machine, sample collector, persistence
+    dataset.py              # Load per-session labels into one frame (+ Parquet cache)
     display/                # Tk calibration overlay, cv2 windows
 
 scripts/extras/             # Standalone utilities
@@ -62,6 +63,7 @@ experimental/               # Paused / on-hold work, kept for reference
 docs/                       # Implementation notes, citations, architecture
     polynomial_gaze_mapping.md      # How the pupil→scene fit works end-to-end
     data_collection.md              # Fields the data-collection pipeline captures
+    dataset_format.md               # On-disk format for sessions + calibration artifacts
     citations/                      # references.bib + references.tex
     architecture/workspace.dsl      # Structurizr C4 model (C1 / C2 / C3)
 

--- a/docs/dataset_format.md
+++ b/docs/dataset_format.md
@@ -1,0 +1,88 @@
+# Dataset & calibration on-disk format
+
+The pipeline records calibration/collection sessions as a **dataset of record** for
+later analysis and CNN training. Each artifact uses the format that fits its job —
+JSON for small structured/provenance data, CSV for append-during-capture sample
+rows, image files for frames, Parquet only at consumption time.
+
+## Layout
+
+```
+data/calibration/
+  session_<ts>/
+    metadata.json            # per-session record (intrinsics, extrinsics, provenance)
+    labels.csv               # one row per accepted sample
+    fixNN_sampleNN.png       # eye-cam frame
+    fixNN_sampleNN_scene.png # scene-cam frame
+  combined.parquet           # planned: cache for whole-dataset training loads
+scripts/eyetracker/
+  calibration.json           # live polynomial model restored at runtime
+  scene_intrinsics.json      # scene-cam intrinsics (K, dist)
+rig_calibrations/
+  <rig_id>.json              # produced by the extrinsics jig
+```
+
+## Artifacts
+
+### `calibration.json` — the live model
+Just what the runtime needs to restore the mapper. Raw samples are **not** stored
+here; they live in the source session's `labels.csv` (named via `source_session`).
+
+```json
+{ "coord_space": "scene", "timestamp": 0.0, "source_session": "session_<ts>",
+  "scene_size": [w, h], "screen_size": [w, h],
+  "model": { "type": "polynomial", "degree": 2, "coeffs_x": [...], "coeffs_y": [...] } }
+```
+
+### `session_<ts>/metadata.json` — the dataset record
+Self-contained: each session inlines a snapshot of the active intrinsics/extrinsics
+so it stays interpretable even if the cameras or central calibration files change.
+Fields the pipeline does not yet produce are `null` placeholders (filled later by the
+extrinsics jig and richer per-frame capture).
+
+```json
+{ "session_id": "session_<ts>", "created_at": "<iso>", "timestamp": 0.0,
+  "phase": "calibration",
+  "subject_id": null, "glasses": null, "headset_model_version": null, "kappa_deg": null,
+  "software": { "pupil_detector": null, "pye3d": null, "app_git_sha": null },
+  "screen":   { "width": w, "height": h },
+  "scene_cam":{ "width": w, "height": h, "fps": null, "identifier": null },
+  "eye_cam":  { "width": w, "height": h, "fps": null, "fov_deg": 80.0, "identifier": null },
+  "aruco":    { "dict_name": "...", "dict_id": n, "marker_px": n, "quiet_zone_px": n,
+                "ids": [...], "screen_centers": [[x, y], ...] },
+  "rig_calibration_id": null,
+  "intrinsics": { "eye": null, "scene": { "K": [[...]], "dist": [...], "reproj_rms": n } },
+  "extrinsics": null,
+  "fit": { "degree": 2, "n_points": n, "loo_avg_px": n, "loo_max_px": n } }
+```
+
+### `labels.csv` — per-sample ground truth
+Columns (see `LABELS_CSV_HEADER` in `calibration/persistence.py`):
+`image_path, fixation_id, x_screen, y_screen, pupil_x, pupil_y, confidence,
+timestamp, scene_target_x, scene_target_y`. Appended row-by-row during capture so a
+mid-session crash keeps what was already written. Richer per-frame fields
+(ellipse params, pye3d 3D vectors, normalized-image paths) from
+`docs/data_collection.md` are added as the pipeline starts producing them.
+
+### `rig_calibrations/<rig_id>.json` — camera-rig calibration (planned)
+Produced by the extrinsics jig (a few days out). Schema is defined now; sessions
+will reference it via `rig_calibration_id` and inline its values into `metadata.json`:
+
+```json
+{ "rig_id": "<ts>", "created_at": "<iso>", "notes": null,
+  "intrinsics": { "eye": {"K":[[...]],"dist":[...]}, "scene": {"K":[[...]],"dist":[...]} },
+  "extrinsics_eye_to_scene": { "R": [[...]], "t": [...], "method": null, "reproj_err": null } }
+```
+
+## Loading for analysis / training
+
+`scripts/eyetracker/dataset.py`:
+- `load_session(dir) -> (metadata, DataFrame)` — one session.
+- `session_dirs(root)` — list every `session_<ts>/` under a root.
+
+Planned (TODO in `dataset.py`, build with the CNN training loop): `load_all` to
+concatenate all sessions + cache `combined.parquet`, and an image-loading layer that
+joins each row's `image_path` to its eye frame.
+
+`scripts/extras/measure_gaze_accuracy.py --session <dir>` refits the polynomial from
+a session and reports LOO error in px and degrees.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 numpy==2.2.6
 opencv-contrib-python==4.13.0.92
 
+# Dataset loading/analysis: glob per-session labels.csv into one frame and cache
+# a typed combined.parquet for training-time loads (scripts/eyetracker/dataset.py).
+pandas==2.2.3
+pyarrow==18.1.0
+
 # Pupil Labs 2D pupil detector — built from local clone.
 # System prereqs: `brew install eigen opencv` (already installed).
 # Build deps (scikit-build, cython) come from the package's pyproject.toml

--- a/scripts/extras/calibrate_scene_intrinsics.py
+++ b/scripts/extras/calibrate_scene_intrinsics.py
@@ -10,18 +10,19 @@ Workflow:
    distances and angles.
 4. Press C to compute calibration. Press R to clear captures. Q to quit.
 
-Output: scripts/eyetracker/scene_intrinsics.npz with K, dist, image_size,
-reproj_rms, timestamp. Use K[0,0] (fx) to convert pixel error to angular:
+Output: scripts/eyetracker/scene_intrinsics.json with K, dist, image_size,
+reproj_rms, timestamp. Use K[0][0] (fx) to convert pixel error to angular:
     angular_deg = degrees(atan(pixel_err / fx))
 """
 import argparse
+import json
 import math
 import sys
 import time
 
 import cv2
-import numpy as np
 
+from scripts.eyetracker.calibration.paths import scene_intrinsics_path
 from scripts.eyetracker.cameras.opencv_source import CameraSettings, OpenCVCamera
 from scripts.eyetracker.config import SCENE_REQUEST_HEIGHT, SCENE_REQUEST_WIDTH
 
@@ -34,7 +35,7 @@ MARKER_LEN = 0.75
 MIN_CORNERS_PER_FRAME = 8
 MIN_FRAMES_FOR_CALIBRATION = 10
 
-OUTPUT_PATH = "scripts/eyetracker/scene_intrinsics.npz"
+OUTPUT_PATH = scene_intrinsics_path()
 WINDOW_NAME = "calibrate_scene_intrinsics"
 
 
@@ -128,12 +129,15 @@ def main():
             )
             print(f"  reproj RMS: {rms:.4f} px")
             _print_K_summary(K, image_size)
-            np.savez(args.out,
-                     K=K, dist=dist,
-                     image_width=image_size[0],
-                     image_height=image_size[1],
-                     reproj_rms=rms,
-                     timestamp=time.time())
+            with open(args.out, "w") as f:
+                json.dump({
+                    "K": K.tolist(),
+                    "dist": dist.tolist(),
+                    "image_width": image_size[0],
+                    "image_height": image_size[1],
+                    "reproj_rms": float(rms),
+                    "timestamp": time.time(),
+                }, f, indent=2)
             print(f"  saved -> {args.out}")
             break
 

--- a/scripts/extras/measure_gaze_accuracy.py
+++ b/scripts/extras/measure_gaze_accuracy.py
@@ -1,59 +1,72 @@
-"""Recompute gaze tracker accuracy from saved calibration + intrinsics.
+"""Recompute gaze tracker accuracy from a saved session.
 
-Loads scripts/eyetracker/calibration_pupil.npz and scene_intrinsics.npz,
-refits the polynomial (deterministic — same lstsq as live calibration),
-and prints LOO error in both pixels and degrees, plus a per-point breakdown.
+Loads a `session_<ts>/` (metadata.json for scene intrinsics + sizes, labels.csv
+for the captured samples), refits the polynomial (deterministic — same lstsq as
+live calibration), and prints LOO error in both pixels and degrees, plus a
+per-point breakdown.
+
+The fit uses the per-fixation median of the raw labels.csv rows, which closely
+tracks the live-calibration fit (live uses the median of inlier samples; this
+uses the median of all collected samples, so numbers can differ slightly).
 
 Useful for:
 - Checking accuracy of past calibration sessions without re-running.
-- Spotting bad fixations (sort by error → outliers float to the top).
+- Spotting bad fixations (sort by error -> outliers float to the top).
 - Tracking accuracy over time after hardware/config changes.
 
-Run:  python -m scripts.extras.measure_gaze_accuracy
+Run:  python -m scripts.extras.measure_gaze_accuracy [--session <dir>]
+      (default: the most recent session under data/calibration/)
 """
 import argparse
 import datetime
 import math
+import sys
 
-import numpy as np
-
+from scripts.eyetracker.calibration.paths import dataset_root
+from scripts.eyetracker.dataset import load_session, session_dirs
 from scripts.eyetracker.gaze.polynomial import PolynomialGazeMapper
 
 
-CAL_PATH = "scripts/eyetracker/calibration_pupil.npz"
-INTR_PATH = "scripts/eyetracker/scene_intrinsics.npz"
-
-
-def _infer_degree(cal) -> int:
-    """Saved cals from before the degree-3 refactor don't have poly_degree.
-    Fall back to inferring from the coefficient-vector length so this script
-    works on both old and new files."""
-    if "poly_degree" in cal.files:
-        return int(cal["poly_degree"])
-    n_coeffs = len(cal["poly_coeffs_x"])
-    return {6: 2, 10: 3}.get(n_coeffs, 2)
+def _resolve_session(arg: str) -> str:
+    if arg:
+        return arg
+    dirs = session_dirs()
+    if not dirs:
+        sys.exit(f"No sessions found under {dataset_root()}")
+    return dirs[-1]
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--cal", default=CAL_PATH)
-    parser.add_argument("--intr", default=INTR_PATH)
+    parser.add_argument("--session", default=None,
+                        help="session dir to analyze (default: most recent)")
     args = parser.parse_args()
 
-    cal = np.load(args.cal)
-    intr = np.load(args.intr)
+    session = _resolve_session(args.session)
+    metadata, df = load_session(session)
+    if metadata is None:
+        sys.exit(f"{session} has no metadata.json (legacy session) — "
+                 "cannot read scene intrinsics.")
+    scene_intr = (metadata.get("intrinsics") or {}).get("scene")
+    if not scene_intr or scene_intr.get("K") is None:
+        sys.exit("Session has no scene intrinsics. Run "
+                 "scripts.extras.calibrate_scene_intrinsics first.")
 
-    fx = float(intr["K"][0, 0])
-    sw = int(cal["scene_width"])
-    sh = int(cal["scene_height"])
-    ts = datetime.datetime.fromtimestamp(float(cal["timestamp"]))
-    V = cal["vectors"]
-    S = cal["scene_points"]
-    SP = cal["screen_points"]
-    degree = _infer_degree(cal)
+    fx = float(scene_intr["K"][0][0])
+    sw = int(metadata["scene_cam"]["width"])
+    sh = int(metadata["scene_cam"]["height"])
+    ts = datetime.datetime.fromtimestamp(float(metadata["timestamp"]))
+    degree = int((metadata.get("fit") or {}).get("degree", 2))
+
+    # Per-fixation median (one point per target), matching the live fit.
+    grouped = df.groupby("fixation_id").median(numeric_only=True)
+    V = grouped[["pupil_x", "pupil_y"]].to_numpy(dtype=float)
+    S = grouped[["scene_target_x", "scene_target_y"]].to_numpy(dtype=float)
+    SP = grouped[["x_screen", "y_screen"]].to_numpy(dtype=float)
 
     print("=" * 68)
-    print(f"Calibration session: {ts}")
+    print(f"Session:             {metadata['session_id']}")
+    print(f"Captured:            {ts}")
     print(f"Scene resolution:    {sw}x{sh}")
     print(f"fx (from intr):      {fx:.2f} px")
     print(f"Polynomial degree:   {degree}")

--- a/scripts/eyetracker/calibration/paths.py
+++ b/scripts/eyetracker/calibration/paths.py
@@ -1,8 +1,10 @@
 """Filesystem locations for calibration artifacts.
 
-The mapper coefficients + last-session metadata live in `calibration_pupil.npz`
-at the package root. Per-session image dumps + labels.csv live under
-`<repo>/data/calibration/session_<timestamp>/`.
+The live mapper model lives in `calibration.json` at the package root, next to
+the scene-cam intrinsics (`scene_intrinsics.json`). Per-session data — eye/scene
+frames, `labels.csv`, and `metadata.json` — lives under
+`<repo>/data/calibration/session_<timestamp>/`. Camera-rig calibrations produced
+by the extrinsics jig live under `<repo>/rig_calibrations/`.
 """
 import os
 
@@ -12,12 +14,21 @@ _REPO_ROOT = os.path.dirname(os.path.dirname(_PACKAGE_DIR))
 
 
 def calibration_path() -> str:
-    return os.path.join(_PACKAGE_DIR, "calibration_pupil.npz")
+    """The live polynomial model restored at runtime."""
+    return os.path.join(_PACKAGE_DIR, "calibration.json")
 
 
-def history_path() -> str:
-    return os.path.join(_PACKAGE_DIR, "calibration_pupil_history.npz")
+def scene_intrinsics_path() -> str:
+    """Scene-cam intrinsics (K, distortion) produced by the intrinsics tool."""
+    return os.path.join(_PACKAGE_DIR, "scene_intrinsics.json")
 
 
 def dataset_root() -> str:
+    """Parent dir holding every captured `session_<timestamp>/`."""
     return os.path.join(_REPO_ROOT, "data", "calibration")
+
+
+def rig_calibrations_root() -> str:
+    """Parent dir for camera-rig calibrations (intrinsics + extrinsics) from
+    the extrinsics jig. One `<rig_id>.json` per jig run."""
+    return os.path.join(_REPO_ROOT, "rig_calibrations")

--- a/scripts/eyetracker/calibration/persistence.py
+++ b/scripts/eyetracker/calibration/persistence.py
@@ -1,6 +1,22 @@
-"""Calibration .npz save/load + per-session dir + labels.csv header.
+"""Calibration persistence: JSON model + per-session metadata + labels.csv.
+
+Three on-disk artifacts, each in the format that fits its job:
+
+- `calibration.json` — the live polynomial model restored at runtime. Just the
+  coefficients + the few fields the runtime needs. Human-readable, no pickle.
+- `session_<ts>/metadata.json` — the per-session dataset record: camera
+  intrinsics/extrinsics, hardware/subject provenance, sizes, aruco config, and a
+  fit summary. Self-contained so a session is interpretable in isolation.
+- `session_<ts>/labels.csv` — one row per accepted calibration sample (the raw
+  ground-truth pairs); appended during capture so a crash mid-session keeps
+  whatever was already written.
+
+The raw sample arrays are NOT duplicated into calibration.json — they live in
+the session's labels.csv (and `metadata.json` records `source_session`).
 """
 import csv
+import datetime
+import json
 import os
 import time
 from dataclasses import dataclass
@@ -12,15 +28,17 @@ import numpy as np
 from scripts.eyetracker.calibration.paths import (
     calibration_path,
     dataset_root,
-    history_path,
+    scene_intrinsics_path,
 )
 from scripts.eyetracker.config import (
     ARUCO_DICT_NAME,
     ARUCO_IDS,
     ARUCO_MARKER_PX,
     ARUCO_QUIET_ZONE_PX,
+    EYE_CAM_FOV_DEG,
+    EYE_CAM_RESOLUTION,
 )
-from scripts.eyetracker.gaze.base import GazeMapper
+from scripts.eyetracker.gaze.base import FitReport, GazeMapper
 
 
 LABELS_CSV_HEADER = [
@@ -48,86 +66,131 @@ class LoadedCalibration:
     screen_size: Optional[Tuple[int, int]]
 
 
-def save_calibration(snapshot: CalibrationSnapshot, mapper: GazeMapper) -> None:
-    """Write the mapper state + session metadata to `calibration_pupil.npz`,
-    and append the (vectors, scene_points) pair to the history file."""
-    path = calibration_path()
-    aruco_dict_id = int(cv2.aruco.DICT_4X4_50) if hasattr(cv2, "aruco") else -1
+def _to_list(arr) -> Optional[list]:
+    """numpy array (or None) -> JSON-serializable nested list (or None)."""
+    if arr is None:
+        return None
+    return np.asarray(arr).tolist()
+
+
+def save_calibration(snapshot: CalibrationSnapshot, mapper: GazeMapper,
+                     source_session: Optional[str] = None) -> None:
+    """Write the live model to `calibration.json`. `source_session` names the
+    session dir whose labels.csv holds the samples this fit came from."""
     state = mapper.state_dict()
-    sw, sh = snapshot.scene_size if snapshot.scene_size is not None else (None, None)
-    pw, ph = snapshot.screen_size if snapshot.screen_size is not None else (None, None)
-    np.savez(path,
-             poly_coeffs_x=state["poly_coeffs_x"],
-             poly_coeffs_y=state["poly_coeffs_y"],
-             vectors=snapshot.pupil_vectors,
-             scene_points=snapshot.scene_points,
-             screen_points=snapshot.screen_points,
-             coord_space="scene",
-             scene_width=sw,
-             scene_height=sh,
-             screen_width=pw,
-             screen_height=ph,
-             aruco_dict_id=aruco_dict_id,
-             aruco_dict_name=ARUCO_DICT_NAME,
-             aruco_marker_px=ARUCO_MARKER_PX,
-             aruco_quiet_zone_px=ARUCO_QUIET_ZONE_PX,
-             aruco_screen_centers=snapshot.aruco_screen_centers,
-             timestamp=time.time())
-    print(f"  Calibration saved to {path}")
-    _append_history(snapshot.pupil_vectors, snapshot.scene_points)
-
-
-def _append_history(vectors: np.ndarray, scene_points: np.ndarray) -> None:
-    hist_path = history_path()
-    if os.path.exists(hist_path):
-        old = np.load(hist_path, allow_pickle=True)
-        if "all_scene_points" in old.files:
-            old_vectors = list(old["all_vectors"])
-            old_scene_points = list(old["all_scene_points"])
-        else:
-            old_vectors = []
-            old_scene_points = []
-    else:
-        old_vectors = []
-        old_scene_points = []
-    old_vectors.append(vectors)
-    old_scene_points.append(scene_points)
-    np.savez(hist_path,
-             all_vectors=np.array(old_vectors, dtype=object),
-             all_scene_points=np.array(old_scene_points, dtype=object))
-    total_pts = sum(len(v) for v in old_vectors)
-    print(f"  History: {len(old_vectors)} sessions, {total_pts} total points.")
+    data = {
+        "coord_space": "scene",
+        "timestamp": time.time(),
+        "source_session": source_session,
+        "scene_size": list(snapshot.scene_size) if snapshot.scene_size else None,
+        "screen_size": list(snapshot.screen_size) if snapshot.screen_size else None,
+        "model": {
+            "type": "polynomial",
+            "degree": int(state["poly_degree"]),
+            "coeffs_x": _to_list(state["poly_coeffs_x"]),
+            "coeffs_y": _to_list(state["poly_coeffs_y"]),
+        },
+    }
+    path = calibration_path()
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    print(f"  Calibration model saved to {path}")
 
 
 def load_calibration(mapper: GazeMapper) -> Optional[LoadedCalibration]:
-    """Restore mapper coefficients from disk and return session metadata.
-    Returns None if no calibration is saved or if the file's coord_space
+    """Restore mapper coefficients from `calibration.json` and return session
+    metadata. Returns None if nothing is saved or if the file's coord_space
     does not match this build (we never want to mix screen/scene fits)."""
     path = calibration_path()
     if not os.path.exists(path):
         print("No saved calibration found.")
         return None
-    data = np.load(path, allow_pickle=True)
-    if "coord_space" not in data.files or str(data["coord_space"]) != "scene":
+    with open(path) as f:
+        data = json.load(f)
+    if data.get("coord_space") != "scene":
         print("  ERROR: saved calibration is not in scene-cam coord space. "
               "Recalibrate with 'c'.")
         return None
+    model = data["model"]
     mapper.load_state_dict({
-        "poly_coeffs_x": data["poly_coeffs_x"],
-        "poly_coeffs_y": data["poly_coeffs_y"],
+        "poly_coeffs_x": np.asarray(model["coeffs_x"]),
+        "poly_coeffs_y": np.asarray(model["coeffs_y"]),
+        "poly_degree": model.get("degree"),
     })
-    screen_size = None
-    scene_size = None
-    if "screen_width" in data.files and "screen_height" in data.files:
-        screen_size = (int(data["screen_width"]), int(data["screen_height"]))
-    if "scene_width" in data.files and "scene_height" in data.files:
-        scene_size = (int(data["scene_width"]), int(data["scene_height"]))
+    scene_size = tuple(data["scene_size"]) if data.get("scene_size") else None
+    screen_size = tuple(data["screen_size"]) if data.get("screen_size") else None
     age_hrs = (time.time() - float(data["timestamp"])) / 3600
     print(f"Calibration loaded (age: {age_hrs:.1f}h, scene={scene_size}).")
     if age_hrs > 24:
         print("  WARNING: Calibration is >24h old. Consider recalibrating.")
     return LoadedCalibration(age_hrs=age_hrs, scene_size=scene_size,
                              screen_size=screen_size)
+
+
+def _scene_intrinsics_snapshot() -> Optional[dict]:
+    """Inline copy of the current scene-cam intrinsics, or None if not yet
+    calibrated. Denormalized into each session so it stays interpretable even
+    if the central intrinsics file later changes."""
+    path = scene_intrinsics_path()
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        intr = json.load(f)
+    return {
+        "K": intr.get("K"),
+        "dist": intr.get("dist"),
+        "reproj_rms": intr.get("reproj_rms"),
+    }
+
+
+def write_session_metadata(session_dir: str,
+                           snapshot: CalibrationSnapshot,
+                           report: FitReport,
+                           degree: int) -> None:
+    """Emit `metadata.json` for a finished session: the self-contained dataset
+    record. Hardware/subject fields that the pipeline does not yet produce
+    (eye intrinsics, extrinsics, subject id, kappa, versions) are written as
+    null placeholders — the extrinsics jig and richer capture fill them later."""
+    sw, sh = snapshot.scene_size if snapshot.scene_size else (None, None)
+    pw, ph = snapshot.screen_size if snapshot.screen_size else (None, None)
+    eye_w, eye_h = EYE_CAM_RESOLUTION
+    aruco_dict_id = int(cv2.aruco.DICT_4X4_50) if hasattr(cv2, "aruco") else -1
+    meta = {
+        "session_id": os.path.basename(os.path.normpath(session_dir)),
+        "created_at": datetime.datetime.now().astimezone().isoformat(),
+        "timestamp": time.time(),
+        "phase": "calibration",
+        "subject_id": None,
+        "glasses": None,
+        "headset_model_version": None,
+        "kappa_deg": None,
+        "software": {"pupil_detector": None, "pye3d": None, "app_git_sha": None},
+        "screen": {"width": pw, "height": ph},
+        "scene_cam": {"width": sw, "height": sh, "fps": None, "identifier": None},
+        "eye_cam": {"width": eye_w, "height": eye_h, "fps": None,
+                    "fov_deg": EYE_CAM_FOV_DEG, "identifier": None},
+        "aruco": {
+            "dict_name": ARUCO_DICT_NAME,
+            "dict_id": aruco_dict_id,
+            "marker_px": ARUCO_MARKER_PX,
+            "quiet_zone_px": ARUCO_QUIET_ZONE_PX,
+            "ids": list(ARUCO_IDS),
+            "screen_centers": _to_list(snapshot.aruco_screen_centers),
+        },
+        "rig_calibration_id": None,
+        "intrinsics": {"eye": None, "scene": _scene_intrinsics_snapshot()},
+        "extrinsics": None,
+        "fit": {
+            "degree": int(degree),
+            "n_points": int(report.n_points),
+            "loo_avg_px": float(report.loo_avg_err),
+            "loo_max_px": float(report.loo_max_err),
+        },
+    }
+    path = os.path.join(session_dir, "metadata.json")
+    with open(path, "w") as f:
+        json.dump(meta, f, indent=2)
+    print(f"  Session metadata saved to {path}")
 
 
 def begin_session(root: Optional[str] = None) -> Tuple[str, str]:

--- a/scripts/eyetracker/calibration/routine.py
+++ b/scripts/eyetracker/calibration/routine.py
@@ -30,6 +30,7 @@ from scripts.eyetracker.calibration.persistence import (
     append_label_rows,
     begin_session,
     save_calibration,
+    write_session_metadata,
 )
 from scripts.eyetracker.calibration.targets import TargetPattern
 from scripts.eyetracker.config import ARUCO_IDS
@@ -383,7 +384,12 @@ class CalibrationRoutine:
         if report.loo_avg_err > err_threshold:
             print(f"  WARNING: High error (>{err_threshold:.0f}px at this "
                   "scene-cam resolution) — consider recalibrating.")
-        save_calibration(snapshot, self.mapper)
+        source_session = (os.path.basename(os.path.normpath(self.session_dir))
+                          if self.session_dir else None)
+        save_calibration(snapshot, self.mapper, source_session=source_session)
+        if self.session_dir is not None:
+            write_session_metadata(self.session_dir, snapshot, report,
+                                   self.mapper_degree)
         print("Calibration Complete!")
 
     def _end(self) -> None:

--- a/scripts/eyetracker/dataset.py
+++ b/scripts/eyetracker/dataset.py
@@ -1,0 +1,54 @@
+"""Read collected calibration sessions for analysis.
+
+A session is a directory `session_<ts>/` under `dataset_root()` containing:
+- `labels.csv` — one row per accepted sample (the ground-truth pairs),
+- the per-sample eye/scene frames, and
+- `metadata.json` — camera intrinsics/extrinsics + provenance (sessions captured
+  before the JSON-metadata change lack this; they're treated as legacy).
+
+This is the read side of the dataset (the capture pipeline writes it). Today the
+only consumer is `scripts/extras/measure_gaze_accuracy.py`, which refits the
+polynomial from one session.
+
+TODO (CNN training work — build when the training loop actually needs it):
+- `load_all(root)`: glob every session's labels.csv into one DataFrame tagged
+  with `session_id`, and cache a typed `combined.parquet` (rebuilt when any
+  session changes) for fast whole-dataset loads. Add `pyarrow` to requirements
+  when this lands — CSV stays the crash-safe capture format, Parquet is the
+  consumption format.
+- An image-loading layer: this module only returns the labels table; a CNN
+  Dataset/DataLoader still needs to read each row's `image_path` (the eye-frame
+  PNG) and join it to the label. That belongs with the training code.
+- Revisit the access pattern then (per-frame vs per-fixation rows, train/val
+  splits, lazy vs eager) — `load_session` may need to grow options.
+"""
+import glob
+import json
+import os
+from typing import List, Optional, Tuple
+
+import pandas as pd
+
+from scripts.eyetracker.calibration.paths import dataset_root
+
+
+def session_dirs(root: Optional[str] = None) -> List[str]:
+    """Every `session_<ts>/` under `root` (default `dataset_root()`), sorted."""
+    base = root if root is not None else dataset_root()
+    return sorted(
+        d for d in glob.glob(os.path.join(base, "session_*"))
+        if os.path.isdir(d)
+    )
+
+
+def load_session(session_dir: str) -> Tuple[Optional[dict], pd.DataFrame]:
+    """Return (metadata, labels). `metadata` is None for legacy sessions with no
+    metadata.json. `labels` gains a `session_id` column for joins/concats."""
+    df = pd.read_csv(os.path.join(session_dir, "labels.csv"))
+    df["session_id"] = os.path.basename(os.path.normpath(session_dir))
+    meta_path = os.path.join(session_dir, "metadata.json")
+    metadata = None
+    if os.path.exists(meta_path):
+        with open(meta_path) as f:
+            metadata = json.load(f)
+    return metadata, df


### PR DESCRIPTION
The .npz layer was doing three ill-fitting jobs: structured metadata (forced
  cast/pickle on load), an append-only history (full read-rewrite, ragged object
  arrays), and raw samples triple-stored across calibration/history/labels. Move
  each to a format that fits, as the foundation for the hardware-agnostic data
  pipeline feeding the eventual CNN.

  - Model: calibration_pupil.npz -> calibration.json (coeffs + degree + sizes + source_session; raw samples no longer duplicated here)
  - Per-session record: new session_<ts>/metadata.json — self-contained dataset record inlining scene intrinsics, with null placeholders for extrinsics, rig_calibration_id, eye intrinsics, subject/kappa/versions (filled later by the extrinsics jig and richer capture)
  - Raw samples: single source of truth in labels.csv (drop the history.npz read-rewrite path)
  - Scene intrinsics: scene_intrinsics.npz -> scene_intrinsics.json
  - Add scripts/eyetracker/dataset.py: load_session/session_dirs read side (TODO: load_all + Parquet cache + image loader for training)
  - measure_gaze_accuracy.py now refits from a session dir (metadata.json + labels.csv) instead of npz
  - paths.py: calibration.json/scene_intrinsics.json helpers, rig_calibrations root; docs/dataset_format.md documents the layout